### PR TITLE
fix: correct user changelog generation regex for header levels

### DIFF
--- a/CHANGELOG_USER.md
+++ b/CHANGELOG_USER.md
@@ -15,9 +15,10 @@ Pour les détails techniques complets, consultez le [CHANGELOG.md](./CHANGELOG.m
 ## Version 2.2.0
 *19 novembre 2025*
 
-### 🐛 Corrections de bugs
+### ✨ Nouvelles fonctionnalités
 
-• retirer autoFocus du formulaire de combat pour mobile
+• add character notebook feature with persistence
+• improve user changelog generation and link
 
 ---
 

--- a/scripts/generate-user-changelog.mjs
+++ b/scripts/generate-user-changelog.mjs
@@ -25,14 +25,19 @@ const version = process.argv[2];
 const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
 const changelog = fs.readFileSync(changelogPath, 'utf-8');
 
-// Extraire la section de la dernière version
-const versionMatch = changelog.match(/## \[([\d.]+)\][\s\S]*?(?=## \[|$)/);
+// Extraire la section de la version spécifique
+// Supporte les titres H1 (#) et H2 (##) générés par semantic-release
+const escapedVersion = version.replace(/\./g, '\\.');
+// Utilisation de (?:^|\n) au lieu du flag 'm' pour éviter que $ ne matche la fin de ligne
+const versionRegex = new RegExp(`(?:^|\\n)#+ \\[${escapedVersion}\\][\\s\\S]*?(?=\\n#+ \\[|$)`);
+const versionMatch = changelog.match(versionRegex);
+
 if (!versionMatch) {
-  console.log('Aucune version trouvée dans CHANGELOG.md');
+  console.log(`Version ${version} non trouvée dans CHANGELOG.md`);
   process.exit(0);
 }
 
-const versionSection = versionMatch[0];
+const versionSection = versionMatch[0].trim();
 
 // Filtrer les types de commits user-friendly
 const userChanges = {


### PR DESCRIPTION
This PR fixes an issue where the user changelog generation script was failing to correctly parse the CHANGELOG.md file when headers were using H1 (#) instead of H2 (##). It also updates the regex to be more robust and targets the specific version passed as an argument.