### PR TITLE
fix(issue-14): adjust current health when max health is reduced

### DIFF
--- a/src/domain/value-objects/Stats.test.ts
+++ b/src/domain/value-objects/Stats.test.ts
@@ -71,6 +71,30 @@ describe('Stats', () => {
       expect(updated.currentHealth).toBe(15);
     });
 
+    it('devrait ajuster la vie actuelle si maxHealth diminue en dessous (issue #14)', () => {
+      const stats = new Stats(7, null, null, 5, 5, 20, 15);
+      const updated = stats.update({ pointsDeVieMax: 10 });
+      
+      expect(updated.maxHealth).toBe(10);
+      expect(updated.currentHealth).toBe(10);
+    });
+
+    it('devrait conserver la vie actuelle si maxHealth augmente', () => {
+      const stats = new Stats(7, null, null, 5, 5, 20, 15);
+      const updated = stats.update({ pointsDeVieMax: 30 });
+      
+      expect(updated.maxHealth).toBe(30);
+      expect(updated.currentHealth).toBe(15);
+    });
+
+    it('devrait respecter la vie actuelle explicitement fournie', () => {
+      const stats = new Stats(7, null, null, 5, 5, 20, 15);
+      const updated = stats.update({ pointsDeVieMax: 10, pointsDeVieActuels: 8 });
+      
+      expect(updated.maxHealth).toBe(10);
+      expect(updated.currentHealth).toBe(8);
+    });
+
     it('devrait valider les nouvelles stats', () => {
       const stats = new Stats(7, null, null, 5, 5, 20, 20);
       

--- a/src/domain/value-objects/Stats.ts
+++ b/src/domain/value-objects/Stats.ts
@@ -58,14 +58,25 @@ export class Stats {
    * Pattern immutable - ne modifie jamais l'instance actuelle
    */
   update(newStats: Partial<StatsData>): Stats {
+    const newMaxHealth = newStats.pointsDeVieMax ?? this.maxHealth;
+    let newCurrentHealth = newStats.pointsDeVieActuels;
+
+    if (newCurrentHealth === undefined) {
+      newCurrentHealth = this.currentHealth;
+    }
+
+    if (newCurrentHealth > newMaxHealth) {
+      newCurrentHealth = newMaxHealth;
+    }
+
     return new Stats(
       newStats.dexterite ?? this.dexterite,
       newStats.constitution !== undefined ? (newStats.constitution ?? null) : this.constitution,
       newStats.reputation !== undefined ? (newStats.reputation ?? null) : this.reputation,
       newStats.chance ?? this.chance,
       newStats.chanceInitiale ?? this.chanceInitiale,
-      newStats.pointsDeVieMax ?? this.maxHealth,
-      newStats.pointsDeVieActuels ?? this.currentHealth
+      newMaxHealth,
+      newCurrentHealth
     );
   }
 


### PR DESCRIPTION
## Résumé
- Corrige le bug où diminuer la vie maximum en dessous de la vie actuelle provoquait une erreur et cassait temporairement la fiche personnage
- La méthode `Stats.update()` ajuste maintenant automatiquement `currentHealth` si le nouveau `maxHealth` est inférieur à la vie actuelle (sauf si `pointsDeVieActuels` est explicitement fourni)

## Changements
- **Stats.ts**: Modifié la méthode `update()` pour ajuster `currentHealth` automatiquement quand `maxHealth` diminue
- **Stats.test.ts**: Ajouté 3 tests pour reproduire et valider le fix

Closes #14