### PR TITLE
feat(ui): adapt AddWeaponModal to use catalog with manual fallback

### DIFF
--- a/components/character/AddWeaponModal.test.tsx
+++ b/components/character/AddWeaponModal.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import AddWeaponModal from '@/components/character/AddWeaponModal';
+
+describe('AddWeaponModal', () => {
+  const onAdd = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render dialog with catalog mode by default', () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    expect(screen.getByText('⚔️ Nouvelle arme')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Catalogue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Manuel' })).toBeInTheDocument();
+  });
+
+  it('should display weapons from catalog', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Arc et carquois')).toBeInTheDocument();
+      expect(screen.getByText('Épée courte (+1)')).toBeInTheDocument();
+      expect(screen.getByText('Épée courte (+2)')).toBeInTheDocument();
+    });
+  });
+
+  it('should filter weapons by search term', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const searchInput = screen.getByPlaceholderText('Rechercher une arme (ex: épée, arc...)');
+    fireEvent.change(searchInput, { target: { value: 'épée' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Épée courte (+1)')).toBeInTheDocument();
+      expect(screen.getByText('Épée courte (+2)')).toBeInTheDocument();
+      expect(screen.queryByText('Arc et carquois')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should call onAdd with correct values when adding from catalog', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const weapon = screen.getByText('Épée courte (+1)');
+    fireEvent.click(weapon);
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledWith('Épée courte (+1)', 1);
+    });
+  });
+
+  it('should close dialog and reset search after adding from catalog', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const searchInput = screen.getByPlaceholderText('Rechercher une arme (ex: épée, arc...)');
+    fireEvent.change(searchInput, { target: { value: 'épée' } });
+
+    const weapon = screen.getByText('Épée courte (+1)');
+    fireEvent.click(weapon);
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should switch to manual mode', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Ex: Épée longue, Arc, Dague...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('0')).toBeInTheDocument();
+    });
+  });
+
+  it('should add weapon manually with correct values', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    const nameInput = screen.getByPlaceholderText('Ex: Épée longue, Arc, Dague...');
+    fireEvent.change(nameInput, { target: { value: 'Hache de guerre' } });
+
+    const attackInput = screen.getByPlaceholderText('0');
+    fireEvent.change(attackInput, { target: { value: '3' } });
+
+    const addButton = screen.getByRole('button', { name: 'Ajouter' });
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledWith('Hache de guerre', 3);
+    });
+  });
+
+  it('should show alert when adding weapon with empty name in manual mode', async () => {
+    const originalAlert = global.alert;
+    const alertSpy = vi.fn();
+    global.alert = alertSpy;
+
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    const addButton = screen.getByRole('button', { name: 'Ajouter' });
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Veuillez entrer un nom d\'arme');
+      expect(onAdd).not.toHaveBeenCalled();
+    });
+
+    global.alert = originalAlert;
+  });
+
+  it('should show alert when adding weapon with invalid attack points in manual mode', async () => {
+    const originalAlert = global.alert;
+    const alertSpy = vi.fn();
+    global.alert = alertSpy;
+
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    const nameInput = screen.getByPlaceholderText('Ex: Épée longue, Arc, Dague...');
+    fireEvent.change(nameInput, { target: { value: 'Épée' } });
+
+    const attackInput = screen.getByPlaceholderText('0');
+    fireEvent.change(attackInput, { target: { value: '-5' } });
+
+    const addButton = screen.getByRole('button', { name: 'Ajouter' });
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Les points d\'attaque doivent être un nombre positif ou nul');
+      expect(onAdd).not.toHaveBeenCalled();
+    });
+
+    global.alert = originalAlert;
+  });
+
+  it('should show empty message when no weapons match search', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const searchInput = screen.getByPlaceholderText('Rechercher une arme (ex: épée, arc...)');
+    fireEvent.change(searchInput, { target: { value: 'xyz' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Aucune arme trouvée. Essayez le mode manuel.')).toBeInTheDocument();
+    });
+  });
+
+  it('should close dialog when clicking close button in manual mode', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    const cancelButton = screen.getByRole('button', { name: 'Annuler' });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should close dialog after adding weapon manually', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    const manualButton = screen.getByRole('button', { name: 'Manuel' });
+    fireEvent.click(manualButton);
+
+    const nameInput = screen.getByPlaceholderText('Ex: Épée longue, Arc, Dague...');
+    fireEvent.change(nameInput, { target: { value: 'Épée longue' } });
+
+    const attackInput = screen.getByPlaceholderText('0');
+    fireEvent.change(attackInput, { target: { value: '2' } });
+
+    const addButton = screen.getByRole('button', { name: 'Ajouter' });
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledWith('Épée longue', 2);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('should display attack points for each weapon from catalog', async () => {
+    render(<AddWeaponModal onAdd={onAdd} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('+0 dégâts')).toBeInTheDocument();
+      expect(screen.getByText('+1 dégâts')).toBeInTheDocument();
+      expect(screen.getByText('+2 dégâts')).toBeInTheDocument();
+    });
+  });
+});

--- a/components/character/AddWeaponModal.tsx
+++ b/components/character/AddWeaponModal.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ITEMS_CATALOG } from "@/src/data/items-catalog";
+import { ItemType } from "@/src/domain/types/items";
 
 interface AddWeaponModalProps {
   onAdd: (name: string, attackPoints: number) => Promise<void>;
@@ -14,25 +19,41 @@ interface AddWeaponModalProps {
 }
 
 export default function AddWeaponModal({ onAdd, onClose }: AddWeaponModalProps) {
-  const [newWeaponName, setNewWeaponName] = useState('');
-  const [newWeaponAttack, setNewWeaponAttack] = useState('');
+  const [mode, setMode] = useState<'catalog' | 'manual'>('catalog');
+  const [search, setSearch] = useState('');
+  const [manualName, setManualName] = useState('');
+  const [manualAttackPoints, setManualAttackPoints] = useState('');
 
-  const handleAdd = async () => {
-    const attack = parseInt(newWeaponAttack);
-    
-    if (!newWeaponName.trim()) {
+  const filteredWeapons = useMemo(() => {
+    return ITEMS_CATALOG
+      .filter((item) => item.type === ItemType.WEAPON)
+      .filter((item) =>
+        item.name.toLowerCase().includes(search.toLowerCase())
+      );
+  }, [search]);
+
+  const handleCatalogWeapon = async (weapon: { name: string; attackPoints?: number }) => {
+    await onAdd(weapon.name, weapon.attackPoints || 0);
+    setSearch('');
+    onClose();
+  };
+
+  const handleManualSubmit = async () => {
+    const attack = parseInt(manualAttackPoints);
+
+    if (!manualName.trim()) {
       alert('Veuillez entrer un nom d\'arme');
       return;
     }
-    
+
     if (isNaN(attack) || attack < 0) {
       alert('Les points d\'attaque doivent être un nombre positif ou nul');
       return;
     }
 
-    await onAdd(newWeaponName.trim(), attack);
-    setNewWeaponName('');
-    setNewWeaponAttack('');
+    await onAdd(manualName.trim(), attack);
+    setManualName('');
+    setManualAttackPoints('');
     onClose();
   };
 
@@ -45,50 +66,111 @@ export default function AddWeaponModal({ onAdd, onClose }: AddWeaponModalProps) 
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 mb-6">
-          <div>
-            <label className="font-[var(--font-merriweather)] text-muted-light text-sm mb-2 block">
-              Nom de l&apos;arme
-            </label>
-            <input
-              type="text"
-              value={newWeaponName}
-              onChange={(e) => setNewWeaponName(e.target.value)}
-              placeholder="Ex: Épée longue, Arc, Dague..."
-              className="w-full bg-background border border-primary/20 rounded px-4 py-2 font-[var(--font-merriweather)] text-light placeholder:text-muted-light focus:outline-none focus:border-primary"
+        <div className="flex gap-2 mb-4">
+          <Button
+            variant={mode === 'catalog' ? 'default' : 'outline'}
+            onClick={() => setMode('catalog')}
+            size="sm"
+            className="flex-1 font-[var(--font-merriweather)]"
+          >
+            Catalogue
+          </Button>
+          <Button
+            variant={mode === 'manual' ? 'default' : 'outline'}
+            onClick={() => setMode('manual')}
+            size="sm"
+            className="flex-1 font-[var(--font-merriweather)]"
+          >
+            Manuel
+          </Button>
+        </div>
+
+        {mode === 'catalog' ? (
+          <>
+            <Input
+              placeholder="Rechercher une arme (ex: épée, arc...)"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="mb-4 font-[var(--font-merriweather)]"
               autoFocus
             />
-          </div>
 
-          <div>
-            <label className="font-[var(--font-merriweather)] text-muted-light text-sm mb-2 block">
-              Points d&apos;attaque
-            </label>
-            <input
-              type="number"
-              value={newWeaponAttack}
-              onChange={(e) => setNewWeaponAttack(e.target.value)}
-              placeholder="0"
-              min="0"
-              className="w-full bg-background border border-primary/20 rounded px-4 py-2 font-[var(--font-geist-mono)] text-light placeholder:text-muted-light focus:outline-none focus:border-primary"
-            />
-          </div>
-        </div>
+            <ScrollArea className="h-[300px] pr-4">
+              <div className="space-y-2">
+                {filteredWeapons.map((weapon) => (
+                  <div
+                    key={weapon.id}
+                    className="flex items-center justify-between p-3 border border-primary/20 rounded-lg hover:bg-accent cursor-pointer transition-colors"
+                    onClick={() => handleCatalogWeapon(weapon)}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium font-[var(--font-merriweather)] text-light truncate">
+                        {weapon.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground font-[var(--font-geist-mono)]">
+                        +{weapon.attackPoints || 0} dégâts
+                      </div>
+                    </div>
+                    <Button size="sm" className="font-[var(--font-merriweather)] shrink-0 ml-2">
+                      Ajouter
+                    </Button>
+                  </div>
+                ))}
 
-        <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 bg-muted hover:bg-muted/80 text-light font-[var(--font-merriweather)] font-bold px-6 py-3 rounded-lg transition-colors border border-primary/20"
-          >
-            Annuler
-          </button>
-          <button
-            onClick={handleAdd}
-            className="flex-1 bg-primary hover:bg-primary/90 text-primary-foreground font-[var(--font-uncial)] font-bold px-6 py-3 rounded-lg transition-all shadow-lg hover:shadow-[0_0_20px_hsl(var(--primary)/0.6)] hover:scale-[1.02] active:scale-[0.98]"
-          >
-            Ajouter
-          </button>
-        </div>
+                {filteredWeapons.length === 0 && (
+                  <div className="text-center text-muted-foreground py-8 font-[var(--font-merriweather)]">
+                    Aucune arme trouvée. Essayez le mode manuel.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </>
+        ) : (
+          <div className="space-y-4 mb-6">
+            <div>
+              <label className="font-[var(--font-merriweather)] text-muted-light text-sm mb-2 block">
+                Nom de l&apos;arme
+              </label>
+              <input
+                type="text"
+                value={manualName}
+                onChange={(e) => setManualName(e.target.value)}
+                placeholder="Ex: Épée longue, Arc, Dague..."
+                className="w-full bg-background border border-primary/20 rounded px-4 py-2 font-[var(--font-merriweather)] text-light placeholder:text-muted-light focus:outline-none focus:border-primary"
+                autoFocus
+              />
+            </div>
+
+            <div>
+              <label className="font-[var(--font-merriweather)] text-muted-light text-sm mb-2 block">
+                Points d&apos;attaque
+              </label>
+              <input
+                type="number"
+                value={manualAttackPoints}
+                onChange={(e) => setManualAttackPoints(e.target.value)}
+                placeholder="0"
+                min="0"
+                className="w-full bg-background border border-primary/20 rounded px-4 py-2 font-[var(--font-geist-mono)] text-light placeholder:text-muted-light focus:outline-none focus:border-primary"
+              />
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 bg-muted hover:bg-muted/80 text-light font-[var(--font-merriweather)] font-bold px-6 py-3 rounded-lg transition-colors border border-primary/20"
+              >
+                Annuler
+              </button>
+              <button
+                onClick={handleManualSubmit}
+                className="flex-1 bg-primary hover:bg-primary/90 text-primary-foreground font-[var(--font-uncial)] font-bold px-6 py-3 rounded-lg transition-all shadow-lg hover:shadow-[0_0_20px_hsl(var(--primary)/0.6)] hover:scale-[1.02] active:scale-[0.98]"
+              >
+                Ajouter
+              </button>
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

- Add catalog mode to `AddWeaponModal` allowing users to select weapons from the official catalog
- Implement search/filter functionality for easy weapon discovery
- Preserve manual mode as fallback for custom weapons not in catalog
- Auto-populate attack points from catalog when selecting a weapon
- Add comprehensive test suite with 13 tests covering all scenarios
- Verify `AddItemModal` already excludes weapons from display

## Details

### Changes Made

1. **AddWeaponModal Component** (`components/character/AddWeaponModal.tsx`)
   - Toggle between Catalog and Manual modes
   - Catalog mode: displays filtered weapons from `ITEMS_CATALOG`
   - Search functionality to filter weapons by name
   - Manual mode: preserved for custom weapon creation
   - Automatic attack points display for catalog weapons

2. **Test Suite** (`components/character/AddWeaponModal.test.tsx`)
   - 13 tests covering:
     - Catalog rendering and filtering
     - Search functionality
     - Manual mode validation
     - Error handling for invalid inputs
     - Form state management

### UX Improvements

- Better user experience with pre-defined weapon stats
- Reduces errors from manual weapon creation
- Consistent UI with `AddItemModal` styling
- Maintains theming (fonts, colors, borders)

### Testing

- ✅ All 198 tests pass
- ✅ Lint passes
- ✅ Build production succeeds

Closes #23