### PR TITLE
ci: add epic/** branches to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'epic/**'
   push:
     branches:
       - main
+      - 'epic/**'
   workflow_call:  # Permet d'être appelé par d'autres workflows
 
 jobs:


### PR DESCRIPTION
## Résumé

Permet aux branches `epic/*` d'avoir les mêmes checks CI que `main`.

---

## 📋 Changements

- Modifie `.github/workflows/ci.yml` pour exécuter la CI sur les branches `epic/**`
- Les branches d'epic de longue durée auront maintenant :
  - Lint (ESLint)
  - Tests (278+ tests)
  - Build Next.js
  - Coverage reports

---

## 🎯 Pourquoi ?

Les branches d'epic (comme `epic/combatV2`) durent plusieurs semaines et nécessitent une validation continue des tests, tout comme la branche `main`.

---

## ✅ Vérification

- Workflow testé localement
- Pattern `epic/**` est conventionnel pour les epic branches