### PR TITLE
feat(combat): implement simplified V3 phase system

### DIFF
--- a/docs/COMBAT_V3.md
+++ b/docs/COMBAT_V3.md
@@ -1,0 +1,216 @@
+# Combat System V3 - Simplified Phase System
+
+## Overview
+
+Combat V3 introduces a simplified phase system with explicit turn tracking, replacing the complex V2 phase machine with a cleaner, more maintainable approach.
+
+## Key Changes from V2
+
+### Phase Simplification
+
+**V2 (6 phases):**
+- `SETUP` → `PLAYER_TURN` → `PLAYER_ATTACK` → `ENEMY_TURN` → `ENEMY_ATTACK` → `ROUND_END` → loop
+
+**V3 (4 phases):**
+- `WAITING_ATTACK_ROLL` → `WAITING_DAMAGE_ROLL` (if hit) → `TURN_COMPLETE` → next turn
+- Or: `WAITING_ATTACK_ROLL` → `TURN_COMPLETE` (if miss) → next turn
+
+### Turn Tracking
+
+**V2:**
+```typescript
+interface CombatState {
+  phase: CombatPhase; // Encodes who's playing
+  currentAttacker: Attacker; // 'player' | 'enemy'
+}
+```
+
+**V3:**
+```typescript
+interface CombatStateV3 {
+  phase: CombatPhaseV3; // Action state
+  currentTurn: CurrentTurn; // 'player' | 'enemy' (explicit)
+}
+```
+
+## Phase Flow
+
+### Complete Round Example
+
+```
+ROUND 1 - Player Turn
+├─ waiting_attack_roll (player) ──[ATTACK]──> hit?
+│  ├─ YES → waiting_damage_roll (player) ──[damage applied]──> turn_complete (player)
+│  └─ NO  → turn_complete (player)
+│
+├─ turn_complete (player) ──[SKIP]──> waiting_attack_roll (enemy)
+│
+ROUND 1 - Enemy Turn (automatic)
+├─ waiting_attack_roll (enemy) ──[auto attack]──> hit?
+│  ├─ YES → waiting_damage_roll (enemy) ──[auto damage]──> turn_complete (enemy)
+│  └─ NO  → turn_complete (enemy)
+│
+├─ turn_complete (enemy) ──[SKIP]──> ROUND 2 - Player Turn
+```
+
+## Available Actions by Phase
+
+| Phase | currentTurn | Actions |
+|-------|------------|---------|
+| `waiting_attack_roll` | `player` | `ATTACK`, `WEAPON_ABILITY` (MANUAL) |
+| `waiting_attack_roll` | `enemy` | (automatic) |
+| `waiting_damage_roll` | `player` | (automatic) |
+| `waiting_damage_roll` | `enemy` | (automatic) |
+| `turn_complete` | * | `SKIP` (advance to next turn) |
+| `ended` | * | (none) |
+
+### Contextual Weapon Abilities
+
+- **ON_MISS** abilities: Available in `turn_complete` after a missed attack
+- **ON_ENEMY_HIT** abilities: Available in `waiting_damage_roll` during enemy turn
+- **MANUAL** abilities: Available in `waiting_attack_roll` during player turn
+- **Auto-triggered** (ON_DOUBLE, ON_KILL, ON_SURPRISE): Never manual
+
+## Round Increment Logic
+
+```typescript
+// Round increments ONLY when enemy completes their turn
+if (phase === TURN_COMPLETE && currentTurn === 'enemy') {
+  roundNumber++; // Start new round
+  currentTurn = 'player';
+  phase = WAITING_ATTACK_ROLL;
+}
+```
+
+## Implementation
+
+### Core Classes
+
+#### PhaseManagerV3
+
+```typescript
+class PhaseManagerV3 {
+  static getInitialPhase(): CombatPhaseV3;
+  static getInitialTurn(firstAttacker: 'player' | 'enemy'): CurrentTurn;
+  
+  static advancePhase(
+    state: CombatStateV3,
+    context: { hit?: boolean; combatEnded?: boolean }
+  ): { phase: CombatPhaseV3; currentTurn: CurrentTurn; roundNumber: number };
+  
+  static skipToNextTurn(state: CombatStateV3): { ... };
+}
+```
+
+#### CombatValidatorV3
+
+```typescript
+class CombatValidatorV3 {
+  static checkCombatEnd(state: CombatStateV3): 'ongoing' | 'victory' | 'defeat';
+  static getAvailableActions(state: CombatStateV3): AvailableAction[];
+}
+```
+
+### State Structure
+
+```typescript
+interface CombatStateV3 {
+  // Identifiers
+  id: string;
+  characterId: string;
+  
+  // Combatants
+  player: PlayerState;
+  enemy: EnemyState;
+  
+  // V3 Core State
+  phase: CombatPhaseV3;
+  currentTurn: CurrentTurn;
+  roundNumber: number;
+  
+  // Context
+  lastRoll?: DiceRoll;
+  pendingDamage?: PendingDamage;
+  usedAbilities: Record<string, number>;
+  usedReroll: boolean;
+  isFirstAttack: boolean;
+  pendingExtraAttack?: boolean;
+  
+  // Config & History
+  config: CombatConfig;
+  events: CombatEvent[];
+  usedItems: UsedItem[];
+}
+```
+
+## Migration from V2
+
+### Breaking Changes
+
+1. **Phase names changed**: `PLAYER_TURN` → `WAITING_ATTACK_ROLL`
+2. **currentAttacker renamed**: `currentAttacker: Attacker` → `currentTurn: CurrentTurn`
+3. **Type change**: `Attacker` enum → string literal type `'player' | 'enemy'`
+
+### Compatibility
+
+- ✅ **WeaponAbilityResolver**: Compatible (uses `WeaponAbilityCheckState` interface)
+- ✅ **CombatEvent**: Unchanged
+- ✅ **PlayerState / EnemyState**: Unchanged
+- ❌ **CombatEngine**: Needs V3 adaptation (future work)
+- ❌ **AttackResolver**: Needs V3 adaptation (future work)
+
+## Testing
+
+### Coverage
+
+- **PhaseManagerV3**: 18 tests
+  - Initial state
+  - Attack roll transitions (hit/miss)
+  - Damage roll transitions
+  - Turn alternation
+  - Round increment
+  - Combat end conditions
+  - Complete flow scenarios
+
+- **CombatValidatorV3**: 15 tests
+  - Combat end detection
+  - Available actions per phase
+  - Weapon ability triggers
+  - Event creation
+
+### Running Tests
+
+```bash
+pnpm test PhaseManagerV3.test.ts
+pnpm test CombatValidatorV3.test.ts
+```
+
+## Files
+
+### New Files
+
+- `src/domain/types/CombatPhaseV3.ts` - Phase enum + CurrentTurn type
+- `src/domain/types/combat-state.ts` - CombatStateV3 interface (added)
+- `src/domain/services/combat/PhaseManagerV3.ts` - Phase logic
+- `src/domain/services/combat/CombatValidatorV3.ts` - Validation logic
+- `tests/domain/services/PhaseManagerV3.test.ts` - Tests (18)
+- `tests/domain/services/CombatValidatorV3.test.ts` - Tests (15)
+
+### Modified Files
+
+- `src/domain/types/index.ts` - Export V3 types
+- `src/domain/services/combat/WeaponAbilityResolver.ts` - Generic compatibility
+
+## Next Steps
+
+1. ✅ **Issue #119**: Simplified phase system (DONE)
+2. 🔄 **Future**: Adapt CombatEngine to use V3
+3. 🔄 **Future**: Create AttackResolverV3
+4. 🔄 **Future**: Update UI components to use V3
+5. 🔄 **Future**: Deprecate V2 system
+
+## References
+
+- Issue #119: https://github.com/bertrandgressier/adventure-tome/issues/119
+- Epic #115: Combat V3
+- Related: Issue #120 (CHANCE restriction)

--- a/src/domain/services/combat/CombatValidatorV3.ts
+++ b/src/domain/services/combat/CombatValidatorV3.ts
@@ -1,0 +1,144 @@
+import type { CombatStateV3, CombatEvent } from '../../types/combat-state';
+import type { AvailableAction } from '../../types/combat-v2';
+import { CombatPhaseV3 } from '../../types/CombatPhaseV3';
+import { CombatActionType } from '../../types/CombatActionType';
+import { CombatEventType } from '../../types/CombatEventType';
+import { WeaponAbilityResolver } from './WeaponAbilityResolver';
+import { WeaponAbilityTrigger } from '../../types/WeaponAbilityTrigger';
+
+export class CombatValidatorV3 {
+  static checkCombatEnd(state: CombatStateV3): 'ongoing' | 'victory' | 'defeat' {
+    if (state.player.endurance <= 0) {
+      return 'defeat';
+    }
+
+    if (state.enemy.endurance <= 0) {
+      return 'victory';
+    }
+
+    return 'ongoing';
+  }
+
+  static getAvailableActions(state: CombatStateV3): AvailableAction[] {
+    const actions: AvailableAction[] = [];
+
+    // WAITING_ATTACK_ROLL - selon qui joue
+    if (state.phase === CombatPhaseV3.WAITING_ATTACK_ROLL) {
+      if (state.currentTurn === 'player') {
+        actions.push({ action: { type: CombatActionType.ATTACK }, enabled: true });
+
+        // TODO: Items consommables (potions, etc.) - pas les weapon abilities
+        // const hasUsableItems = ...;
+        // if (hasUsableItems) {
+        //   actions.push({ action: { type: CombatActionType.USE_ITEM, payload: {} }, enabled: true });
+        // }
+
+        // Weapon abilities (MANUAL trigger) - ajoutées ici, pas à la fin
+        const weaponAbility = state.player.weapon.ability;
+        if (weaponAbility && weaponAbility.trigger === WeaponAbilityTrigger.MANUAL) {
+          const { canUse, reason } = WeaponAbilityResolver.canUseAbility(state, weaponAbility.id);
+          actions.push({
+            action: {
+              type: CombatActionType.WEAPON_ABILITY,
+              payload: { abilityId: weaponAbility.id },
+            },
+            enabled: canUse,
+            disabledReason: canUse ? undefined : reason,
+          });
+        }
+      }
+      // Enemy turn: actions automatiques (pas d'actions manuelles)
+      return actions;
+    }
+
+    // WAITING_DAMAGE_ROLL - automatique, passe à turn_complete via SKIP
+    if (state.phase === CombatPhaseV3.WAITING_DAMAGE_ROLL) {
+      // Les dégâts sont appliqués automatiquement
+      // Le joueur peut simplement passer (via SKIP implicite)
+      // Enemy damage roll est aussi automatique
+    }
+
+    // TURN_COMPLETE - skip to next turn
+    if (state.phase === CombatPhaseV3.TURN_COMPLETE) {
+      actions.push({ action: { type: CombatActionType.SKIP }, enabled: true });
+    }
+
+    // Weapon abilities contextuelles (ON_MISS, ON_ENEMY_HIT)
+    const weaponAbility = state.player.weapon.ability;
+    if (
+      weaponAbility &&
+      state.currentTurn === 'player' &&
+      this.isAbilityAvailableInCurrentPhase(state, weaponAbility.trigger)
+    ) {
+      const { canUse, reason } = WeaponAbilityResolver.canUseAbility(state, weaponAbility.id);
+      actions.push({
+        action: { type: CombatActionType.WEAPON_ABILITY, payload: { abilityId: weaponAbility.id } },
+        enabled: canUse,
+        disabledReason: canUse ? undefined : reason,
+      });
+    }
+
+    return actions;
+  }
+
+  /**
+   * Vérifie si une capacité d'arme est disponible dans la phase actuelle
+   */
+  private static isAbilityAvailableInCurrentPhase(
+    state: CombatStateV3,
+    trigger: WeaponAbilityTrigger
+  ): boolean {
+    switch (trigger) {
+      case WeaponAbilityTrigger.ON_MISS:
+        // Disponible après un raté (turn_complete après miss)
+        return (
+          state.phase === CombatPhaseV3.TURN_COMPLETE &&
+          state.lastRoll !== undefined &&
+          !state.lastRoll.success
+        );
+
+      case WeaponAbilityTrigger.ON_ENEMY_HIT:
+        // Disponible quand l'ennemi attaque (waiting_damage_roll en enemy turn)
+        return state.phase === CombatPhaseV3.WAITING_DAMAGE_ROLL && state.currentTurn === 'enemy';
+
+      case WeaponAbilityTrigger.MANUAL:
+        // Disponible pendant waiting_attack_roll (player turn)
+        return state.phase === CombatPhaseV3.WAITING_ATTACK_ROLL && state.currentTurn === 'player';
+
+      case WeaponAbilityTrigger.ON_DOUBLE:
+      case WeaponAbilityTrigger.ON_KILL:
+      case WeaponAbilityTrigger.ON_SURPRISE:
+        // Auto-triggered, jamais manuel
+        return false;
+
+      default:
+        return false;
+    }
+  }
+
+  static createCombatEndEvent(state: CombatStateV3, result: 'victory' | 'defeat'): CombatEvent {
+    return {
+      type: CombatEventType.COMBAT_END,
+      timestamp: new Date().toISOString(),
+      round: state.roundNumber,
+      attacker: state.currentTurn === 'player' ? 'player' : 'enemy',
+      result,
+    };
+  }
+
+  static createRoundStartEvent(roundNumber: number): CombatEvent {
+    return {
+      type: CombatEventType.ROUND_START,
+      timestamp: new Date().toISOString(),
+      round: roundNumber,
+    };
+  }
+
+  static createRoundEndEvent(roundNumber: number): CombatEvent {
+    return {
+      type: CombatEventType.ROUND_END,
+      timestamp: new Date().toISOString(),
+      round: roundNumber,
+    };
+  }
+}

--- a/src/domain/services/combat/PhaseManagerV3.ts
+++ b/src/domain/services/combat/PhaseManagerV3.ts
@@ -1,0 +1,105 @@
+import type { CombatStateV3 } from '../../types/combat-state';
+import { CombatPhaseV3, type CurrentTurn } from '../../types/CombatPhaseV3';
+
+export class PhaseManagerV3 {
+  /**
+   * Détermine la phase initiale du combat selon le premier attaquant
+   */
+  static getInitialPhase(): CombatPhaseV3 {
+    return CombatPhaseV3.WAITING_ATTACK_ROLL;
+  }
+
+  /**
+   * Détermine le tour initial selon firstAttacker
+   */
+  static getInitialTurn(firstAttacker: 'player' | 'enemy'): CurrentTurn {
+    return firstAttacker;
+  }
+
+  /**
+   * Avance la phase selon l'état actuel et le résultat de l'action
+   */
+  static advancePhase(
+    state: CombatStateV3,
+    context: {
+      hit?: boolean;
+      combatEnded?: boolean;
+    }
+  ): { phase: CombatPhaseV3; currentTurn: CurrentTurn; roundNumber: number } {
+    if (context.combatEnded) {
+      return {
+        phase: CombatPhaseV3.ENDED,
+        currentTurn: state.currentTurn,
+        roundNumber: state.roundNumber,
+      };
+    }
+
+    switch (state.phase) {
+      case CombatPhaseV3.WAITING_ATTACK_ROLL:
+        if (context.hit) {
+          return {
+            phase: CombatPhaseV3.WAITING_DAMAGE_ROLL,
+            currentTurn: state.currentTurn,
+            roundNumber: state.roundNumber,
+          };
+        } else {
+          return {
+            phase: CombatPhaseV3.TURN_COMPLETE,
+            currentTurn: state.currentTurn,
+            roundNumber: state.roundNumber,
+          };
+        }
+
+      case CombatPhaseV3.WAITING_DAMAGE_ROLL:
+        return {
+          phase: CombatPhaseV3.TURN_COMPLETE,
+          currentTurn: state.currentTurn,
+          roundNumber: state.roundNumber,
+        };
+
+      case CombatPhaseV3.TURN_COMPLETE: {
+        const nextTurn: CurrentTurn = state.currentTurn === 'player' ? 'enemy' : 'player';
+        const shouldIncrementRound = state.currentTurn === 'enemy';
+
+        return {
+          phase: CombatPhaseV3.WAITING_ATTACK_ROLL,
+          currentTurn: nextTurn,
+          roundNumber: shouldIncrementRound ? state.roundNumber + 1 : state.roundNumber,
+        };
+      }
+
+      case CombatPhaseV3.ENDED:
+        return {
+          phase: CombatPhaseV3.ENDED,
+          currentTurn: state.currentTurn,
+          roundNumber: state.roundNumber,
+        };
+
+      default:
+        return {
+          phase: state.phase,
+          currentTurn: state.currentTurn,
+          roundNumber: state.roundNumber,
+        };
+    }
+  }
+
+  /**
+   * Passe au tour suivant (action SKIP sur turn_complete)
+   */
+  static skipToNextTurn(state: CombatStateV3): {
+    phase: CombatPhaseV3;
+    currentTurn: CurrentTurn;
+    roundNumber: number;
+  } {
+    if (state.phase !== CombatPhaseV3.TURN_COMPLETE) {
+      return {
+        phase: state.phase,
+        currentTurn: state.currentTurn,
+        roundNumber: state.roundNumber,
+      };
+    }
+
+    return this.advancePhase(state, {});
+  }
+}

--- a/src/domain/services/combat/WeaponAbilityResolver.ts
+++ b/src/domain/services/combat/WeaponAbilityResolver.ts
@@ -1,9 +1,29 @@
 import type { CombatState, CombatEvent } from '../../types/combat-v2';
-import type { WeaponAbility, DiceRoll } from '../../types/combatants';
+import type { CombatStateV3 } from '../../types/combat-state';
+import type { WeaponAbility, DiceRoll, PendingDamage } from '../../types/combatants';
 import { CombatEventType } from '../../types/CombatEventType';
 import { CombatPhase } from '../../types/CombatPhase';
 import { WeaponAbilityTrigger } from '../../types/WeaponAbilityTrigger';
 import { COMBAT_MESSAGES } from './constants';
+
+/**
+ * Type union des états de combat compatibles avec WeaponAbilityResolver
+ */
+export type CompatibleCombatState = CombatState | CombatStateV3;
+
+/**
+ * Interface commune minimale pour les vérifications d'armes légendaires
+ */
+export interface WeaponAbilityCheckState {
+  player: {
+    weapon: {
+      ability?: WeaponAbility;
+    };
+    chance: number;
+  };
+  usedAbilities: Record<string, number>;
+  pendingDamage?: PendingDamage;
+}
 
 export interface TriggerContext {
   roll?: DiceRoll;
@@ -49,7 +69,7 @@ export class WeaponAbilityResolver {
   }
 
   static canUseAbility(
-    state: CombatState,
+    state: WeaponAbilityCheckState,
     abilityId: string
   ): { canUse: boolean; reason?: string } {
     const weapon = state.player.weapon;

--- a/src/domain/types/CombatPhaseV3.ts
+++ b/src/domain/types/CombatPhaseV3.ts
@@ -1,0 +1,18 @@
+/**
+ * CombatPhaseV3 - Phases simplifiées du système de combat V3
+ * 
+ * Flow: waiting_attack_roll → waiting_damage_roll (si touché) → turn_complete → ROUND N+1
+ */
+export const CombatPhaseV3 = {
+  WAITING_ATTACK_ROLL: 'waiting_attack_roll',
+  WAITING_DAMAGE_ROLL: 'waiting_damage_roll',
+  TURN_COMPLETE: 'turn_complete',
+  ENDED: 'ended',
+} as const;
+
+export type CombatPhaseV3 = (typeof CombatPhaseV3)[keyof typeof CombatPhaseV3];
+
+/**
+ * CurrentTurn - Indique qui joue actuellement
+ */
+export type CurrentTurn = 'player' | 'enemy';

--- a/src/domain/types/combat-state.ts
+++ b/src/domain/types/combat-state.ts
@@ -1,4 +1,5 @@
 import type { CombatPhase } from './CombatPhase';
+import type { CombatPhaseV3, CurrentTurn } from './CombatPhaseV3';
 import type { CombatActionType } from './CombatActionType';
 import type { Attacker } from './Attacker';
 import type { PlayerState, EnemyState, DiceRoll, PendingDamage, CombatConfig } from './combatants';
@@ -29,6 +30,28 @@ export interface CombatState {
   config: CombatConfig;
   events: CombatEvent[];
   /** Items utilisés pendant le combat, à consommer via consumeItem() à la fin */
+  usedItems: UsedItem[];
+}
+
+/**
+ * CombatStateV3 - État du combat avec phases simplifiées et currentTurn
+ */
+export interface CombatStateV3 {
+  id: string;
+  characterId: string;
+  player: PlayerState;
+  enemy: EnemyState;
+  phase: CombatPhaseV3;
+  currentTurn: CurrentTurn;
+  roundNumber: number;
+  lastRoll?: DiceRoll;
+  pendingDamage?: PendingDamage;
+  usedAbilities: Record<string, number>;
+  usedReroll: boolean;
+  isFirstAttack: boolean;
+  pendingExtraAttack?: boolean;
+  config: CombatConfig;
+  events: CombatEvent[];
   usedItems: UsedItem[];
 }
 

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -5,6 +5,10 @@ export type { CombatState as CombatStateV1 } from './combat';
 // V2 Combat types (current)
 export * from './combat-v2';
 
+// V3 Combat types (new simplified system)
+export { CombatPhaseV3, type CurrentTurn } from './CombatPhaseV3';
+export type { CombatStateV3 } from './combat-state';
+
 // Combat constants
 export { CombatActionType } from './CombatActionType';
 export { CombatEventType } from './CombatEventType';

--- a/tests/domain/services/CombatValidatorV3.test.ts
+++ b/tests/domain/services/CombatValidatorV3.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect } from 'vitest';
+import { CombatValidatorV3 } from '../../../src/domain/services/combat/CombatValidatorV3';
+import { CombatPhaseV3 } from '../../../src/domain/types/CombatPhaseV3';
+import { CombatActionType } from '../../../src/domain/types/CombatActionType';
+import { WeaponAbilityTrigger } from '../../../src/domain/types/WeaponAbilityTrigger';
+import { WeaponEffectType } from '../../../src/domain/types/WeaponEffectType';
+import type { CombatStateV3 } from '../../../src/domain/types/combat-state';
+import { CombatEventType } from '../../../src/domain/types/CombatEventType';
+
+describe('CombatValidatorV3', () => {
+  const createMockState = (
+    phase: CombatPhaseV3,
+    currentTurn: 'player' | 'enemy',
+    overrides?: Partial<CombatStateV3>
+  ): CombatStateV3 => ({
+    id: 'test-combat',
+    characterId: 'test-char',
+    player: {
+      name: 'Hero',
+      dexterite: 10,
+      endurance: 20,
+      enduranceMax: 20,
+      chance: 10,
+      weaponDamage: 2,
+      passiveDamageBonus: 0,
+      totalDamageBonus: 2,
+      weapon: {
+        id: 'sword',
+        name: 'Épée',
+        bonus: 2,
+      },
+    },
+    enemy: {
+      name: 'Goblin',
+      dexterite: 8,
+      endurance: 10,
+      enduranceMax: 10,
+      weaponDamage: 0,
+      passiveDamageBonus: 0,
+      totalDamageBonus: 0,
+    },
+    phase,
+    currentTurn,
+    roundNumber: 1,
+    usedAbilities: {},
+    usedReroll: false,
+    isFirstAttack: true,
+    config: {
+      damageFormula: '1d6',
+      firstAttacker: 'player',
+      isSurprise: false,
+    },
+    events: [
+      {
+        type: CombatEventType.COMBAT_START,
+        timestamp: new Date().toISOString(),
+        round: 1,
+      },
+    ],
+    usedItems: [],
+    ...overrides,
+  });
+
+  describe('checkCombatEnd', () => {
+    it('should return ongoing when both combatants are alive', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player');
+      const result = CombatValidatorV3.checkCombatEnd(state);
+      expect(result).toBe('ongoing');
+    });
+
+    it('should return victory when enemy endurance reaches 0', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_DAMAGE_ROLL, 'player', {
+        enemy: {
+          name: 'Goblin',
+          dexterite: 8,
+          endurance: 0,
+          enduranceMax: 10,
+          weaponDamage: 0,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 0,
+        },
+      });
+      const result = CombatValidatorV3.checkCombatEnd(state);
+      expect(result).toBe('victory');
+    });
+
+    it('should return defeat when player endurance reaches 0', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_DAMAGE_ROLL, 'enemy', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 0,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'sword',
+            name: 'Épée',
+            bonus: 2,
+          },
+        },
+      });
+      const result = CombatValidatorV3.checkCombatEnd(state);
+      expect(result).toBe('defeat');
+    });
+  });
+
+  describe('getAvailableActions - WAITING_ATTACK_ROLL', () => {
+    it('should return ATTACK and WEAPON_ABILITY during player turn with MANUAL ability', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 20,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'legendary-sword',
+            name: 'Épée Légendaire',
+            bonus: 3,
+            ability: {
+              id: 'double-strike',
+              name: 'Double frappe',
+              trigger: WeaponAbilityTrigger.MANUAL,
+              effect: { type: WeaponEffectType.EXTRA_ATTACK },
+              usesPerCombat: 1,
+            },
+          },
+        },
+      });
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      expect(actions).toHaveLength(2);
+      expect(actions.find((a) => a.action.type === CombatActionType.ATTACK)).toBeDefined();
+      expect(actions.find((a) => a.action.type === CombatActionType.WEAPON_ABILITY)).toBeDefined();
+    });
+
+    it('should return only ATTACK during player turn without weapon ability', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player');
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].action.type).toBe(CombatActionType.ATTACK);
+    });
+
+    it('should return empty actions during enemy turn (automatic)', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'enemy');
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      expect(actions).toHaveLength(0);
+    });
+  });
+
+  describe('getAvailableActions - TURN_COMPLETE', () => {
+    it('should return SKIP action', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player');
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].action.type).toBe(CombatActionType.SKIP);
+      expect(actions[0].enabled).toBe(true);
+    });
+  });
+
+  describe('getAvailableActions - ENDED', () => {
+    it('should return no actions when combat is ended', () => {
+      const state = createMockState(CombatPhaseV3.ENDED, 'player', {
+        enemy: {
+          name: 'Goblin',
+          dexterite: 8,
+          endurance: 0,
+          enduranceMax: 10,
+          weaponDamage: 0,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 0,
+        },
+      });
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      expect(actions).toHaveLength(0);
+    });
+  });
+
+  describe('getAvailableActions - weapon abilities by trigger', () => {
+    it('should show ON_MISS ability after a missed attack', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 20,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'arc-des-vents',
+            name: 'Arc des Vents',
+            bonus: 2,
+            ability: {
+              id: 'convert-miss',
+              name: 'Convertir raté',
+              trigger: WeaponAbilityTrigger.ON_MISS,
+              effect: { type: WeaponEffectType.CONVERT_MISS_TO_HIT },
+              usesPerCombat: 1,
+            },
+          },
+        },
+        lastRoll: {
+          dice1: 6,
+          dice2: 6,
+          total: 12,
+          success: false,
+        },
+      });
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      const weaponAbilityAction = actions.find(
+        (a) => a.action.type === CombatActionType.WEAPON_ABILITY
+      );
+      expect(weaponAbilityAction).toBeDefined();
+      expect(weaponAbilityAction?.enabled).toBe(true);
+    });
+
+    it('should NOT show ON_MISS ability when attack hit', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 20,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'arc-des-vents',
+            name: 'Arc des Vents',
+            bonus: 2,
+            ability: {
+              id: 'convert-miss',
+              name: 'Convertir raté',
+              trigger: WeaponAbilityTrigger.ON_MISS,
+              effect: { type: WeaponEffectType.CONVERT_MISS_TO_HIT },
+              usesPerCombat: 1,
+            },
+          },
+        },
+        lastRoll: {
+          dice1: 2,
+          dice2: 3,
+          total: 5,
+          success: true,
+        },
+      });
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      const weaponAbilityAction = actions.find(
+        (a) => a.action.type === CombatActionType.WEAPON_ABILITY
+      );
+      expect(weaponAbilityAction).toBeUndefined();
+    });
+
+    it('should NOT show auto-triggered abilities (ON_DOUBLE, ON_KILL, ON_SURPRISE)', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 20,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'auto-trigger-weapon',
+            name: 'Arme Auto',
+            bonus: 2,
+            ability: {
+              id: 'on-double',
+              name: 'Sur double',
+              trigger: WeaponAbilityTrigger.ON_DOUBLE,
+              effect: { type: WeaponEffectType.EXTRA_ATTACK },
+            },
+          },
+        },
+      });
+
+      const actions = CombatValidatorV3.getAvailableActions(state);
+
+      const weaponAbilityAction = actions.find(
+        (a) => a.action.type === CombatActionType.WEAPON_ABILITY
+      );
+      expect(weaponAbilityAction).toBeUndefined();
+    });
+  });
+
+  describe('createCombatEndEvent', () => {
+    it('should create victory event', () => {
+      const state = createMockState(CombatPhaseV3.ENDED, 'player', {
+        enemy: {
+          name: 'Goblin',
+          dexterite: 8,
+          endurance: 0,
+          enduranceMax: 10,
+          weaponDamage: 0,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 0,
+        },
+      });
+
+      const event = CombatValidatorV3.createCombatEndEvent(state, 'victory');
+
+      expect(event.type).toBe(CombatEventType.COMBAT_END);
+      expect(event.result).toBe('victory');
+      expect(event.round).toBe(1);
+      expect(event.attacker).toBe('player');
+    });
+
+    it('should create defeat event', () => {
+      const state = createMockState(CombatPhaseV3.ENDED, 'enemy', {
+        player: {
+          name: 'Hero',
+          dexterite: 10,
+          endurance: 0,
+          enduranceMax: 20,
+          chance: 10,
+          weaponDamage: 2,
+          passiveDamageBonus: 0,
+          totalDamageBonus: 2,
+          weapon: {
+            id: 'sword',
+            name: 'Épée',
+            bonus: 2,
+          },
+        },
+      });
+
+      const event = CombatValidatorV3.createCombatEndEvent(state, 'defeat');
+
+      expect(event.type).toBe(CombatEventType.COMBAT_END);
+      expect(event.result).toBe('defeat');
+      expect(event.attacker).toBe('enemy');
+    });
+  });
+
+  describe('createRoundStartEvent', () => {
+    it('should create round start event', () => {
+      const event = CombatValidatorV3.createRoundStartEvent(2);
+
+      expect(event.type).toBe(CombatEventType.ROUND_START);
+      expect(event.round).toBe(2);
+      expect(event.timestamp).toBeDefined();
+    });
+  });
+
+  describe('createRoundEndEvent', () => {
+    it('should create round end event', () => {
+      const event = CombatValidatorV3.createRoundEndEvent(1);
+
+      expect(event.type).toBe(CombatEventType.ROUND_END);
+      expect(event.round).toBe(1);
+      expect(event.timestamp).toBeDefined();
+    });
+  });
+});

--- a/tests/domain/services/PhaseManagerV3.test.ts
+++ b/tests/domain/services/PhaseManagerV3.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import { PhaseManagerV3 } from '../../../src/domain/services/combat/PhaseManagerV3';
+import { CombatPhaseV3 } from '../../../src/domain/types/CombatPhaseV3';
+import type { CombatStateV3 } from '../../../src/domain/types/combat-state';
+import { CombatEventType } from '../../../src/domain/types/CombatEventType';
+
+describe('PhaseManagerV3', () => {
+  const createMockState = (
+    phase: CombatPhaseV3,
+    currentTurn: 'player' | 'enemy',
+    roundNumber: number,
+    overrides?: Partial<CombatStateV3>
+  ): CombatStateV3 => ({
+    id: 'test-combat',
+    characterId: 'test-char',
+    player: {
+      name: 'Hero',
+      dexterite: 10,
+      endurance: 20,
+      enduranceMax: 20,
+      chance: 10,
+      weaponDamage: 2,
+      passiveDamageBonus: 0,
+      totalDamageBonus: 2,
+      weapon: {
+        id: 'sword',
+        name: 'Épée',
+        bonus: 2,
+      },
+    },
+    enemy: {
+      name: 'Goblin',
+      dexterite: 8,
+      endurance: 10,
+      enduranceMax: 10,
+      weaponDamage: 0,
+      passiveDamageBonus: 0,
+      totalDamageBonus: 0,
+    },
+    phase,
+    currentTurn,
+    roundNumber,
+    usedAbilities: {},
+    usedReroll: false,
+    isFirstAttack: true,
+    config: {
+      damageFormula: '1d6',
+      firstAttacker: 'player',
+      isSurprise: false,
+    },
+    events: [
+      {
+        type: CombatEventType.COMBAT_START,
+        timestamp: new Date().toISOString(),
+        round: 1,
+      },
+    ],
+    usedItems: [],
+    ...overrides,
+  });
+
+  describe('getInitialPhase', () => {
+    it('should return WAITING_ATTACK_ROLL as initial phase', () => {
+      const phase = PhaseManagerV3.getInitialPhase();
+      expect(phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+    });
+  });
+
+  describe('getInitialTurn', () => {
+    it('should start with player turn when firstAttacker is player', () => {
+      const turn = PhaseManagerV3.getInitialTurn('player');
+      expect(turn).toBe('player');
+    });
+
+    it('should start with enemy turn when firstAttacker is enemy', () => {
+      const turn = PhaseManagerV3.getInitialTurn('enemy');
+      expect(turn).toBe('enemy');
+    });
+  });
+
+  describe('advancePhase - attack roll transitions', () => {
+    it('should transition to waiting_damage_roll on successful hit', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, { hit: true });
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_DAMAGE_ROLL);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(1);
+    });
+
+    it('should transition to turn_complete on miss', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, { hit: false });
+
+      expect(result.phase).toBe(CombatPhaseV3.TURN_COMPLETE);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(1);
+    });
+
+    it('should transition to ended when combat ends during attack', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, { hit: true, combatEnded: true });
+
+      expect(result.phase).toBe(CombatPhaseV3.ENDED);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(1);
+    });
+  });
+
+  describe('advancePhase - damage roll transitions', () => {
+    it('should transition to turn_complete after damage roll', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_DAMAGE_ROLL, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, {});
+
+      expect(result.phase).toBe(CombatPhaseV3.TURN_COMPLETE);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(1);
+    });
+
+    it('should transition to ended when combat ends after damage', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_DAMAGE_ROLL, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, { combatEnded: true });
+
+      expect(result.phase).toBe(CombatPhaseV3.ENDED);
+    });
+  });
+
+  describe('advancePhase - turn complete transitions', () => {
+    it('should alternate turns after turn_complete (player to enemy)', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, {});
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('enemy');
+      expect(result.roundNumber).toBe(1); // Same round
+    });
+
+    it('should alternate turns after turn_complete (enemy to player)', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'enemy', 1);
+      const result = PhaseManagerV3.advancePhase(state, {});
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(2); // New round
+    });
+
+    it('should increment roundNumber after both turns (enemy turn complete)', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'enemy', 1);
+      const result = PhaseManagerV3.advancePhase(state, {});
+
+      expect(result.roundNumber).toBe(2);
+    });
+
+    it('should NOT increment roundNumber after player turn complete', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player', 1);
+      const result = PhaseManagerV3.advancePhase(state, {});
+
+      expect(result.roundNumber).toBe(1);
+    });
+  });
+
+  describe('advancePhase - combat end conditions', () => {
+    it('should end combat when player HP reaches 0', () => {
+      const state = createMockState(
+        CombatPhaseV3.WAITING_DAMAGE_ROLL,
+        'enemy',
+        2,
+        {
+          player: {
+            name: 'Hero',
+            dexterite: 10,
+            endurance: 0, // Dead
+            enduranceMax: 20,
+            chance: 10,
+            weaponDamage: 2,
+            passiveDamageBonus: 0,
+            totalDamageBonus: 2,
+            weapon: {
+              id: 'sword',
+              name: 'Épée',
+              bonus: 2,
+            },
+          },
+        }
+      );
+
+      const result = PhaseManagerV3.advancePhase(state, { combatEnded: true });
+
+      expect(result.phase).toBe(CombatPhaseV3.ENDED);
+    });
+
+    it('should end combat when enemy HP reaches 0', () => {
+      const state = createMockState(
+        CombatPhaseV3.WAITING_DAMAGE_ROLL,
+        'player',
+        2,
+        {
+          enemy: {
+            name: 'Goblin',
+            dexterite: 8,
+            endurance: 0, // Dead
+            enduranceMax: 10,
+            weaponDamage: 0,
+            passiveDamageBonus: 0,
+            totalDamageBonus: 0,
+          },
+        }
+      );
+
+      const result = PhaseManagerV3.advancePhase(state, { combatEnded: true });
+
+      expect(result.phase).toBe(CombatPhaseV3.ENDED);
+    });
+  });
+
+  describe('skipToNextTurn', () => {
+    it('should advance to next turn from turn_complete', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'player', 1);
+      const result = PhaseManagerV3.skipToNextTurn(state);
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('enemy');
+      expect(result.roundNumber).toBe(1);
+    });
+
+    it('should NOT change phase if not in turn_complete', () => {
+      const state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', 1);
+      const result = PhaseManagerV3.skipToNextTurn(state);
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(1);
+    });
+
+    it('should increment round when enemy completes turn', () => {
+      const state = createMockState(CombatPhaseV3.TURN_COMPLETE, 'enemy', 1);
+      const result = PhaseManagerV3.skipToNextTurn(state);
+
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(2);
+    });
+  });
+
+  describe('complete combat flow', () => {
+    it('should follow correct flow: player hit → damage → enemy miss → complete round', () => {
+      // Round 1 - Player turn
+      let state = createMockState(CombatPhaseV3.WAITING_ATTACK_ROLL, 'player', 1);
+
+      // Player attacks and hits
+      let result = PhaseManagerV3.advancePhase(state, { hit: true });
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_DAMAGE_ROLL);
+      expect(result.currentTurn).toBe('player');
+
+      // Player rolls damage
+      state = { ...state, phase: result.phase };
+      result = PhaseManagerV3.advancePhase(state, {});
+      expect(result.phase).toBe(CombatPhaseV3.TURN_COMPLETE);
+      expect(result.currentTurn).toBe('player');
+
+      // Skip to enemy turn
+      state = { ...state, phase: result.phase };
+      result = PhaseManagerV3.skipToNextTurn(state);
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('enemy');
+      expect(result.roundNumber).toBe(1);
+
+      // Enemy attacks and misses
+      state = { ...state, phase: result.phase, currentTurn: result.currentTurn };
+      result = PhaseManagerV3.advancePhase(state, { hit: false });
+      expect(result.phase).toBe(CombatPhaseV3.TURN_COMPLETE);
+      expect(result.currentTurn).toBe('enemy');
+
+      // Skip to next round (player turn)
+      state = { ...state, phase: result.phase, roundNumber: result.roundNumber };
+      result = PhaseManagerV3.skipToNextTurn(state);
+      expect(result.phase).toBe(CombatPhaseV3.WAITING_ATTACK_ROLL);
+      expect(result.currentTurn).toBe('player');
+      expect(result.roundNumber).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## 🎯 Objectif

Implémenter le système de phases simplifié pour Combat V3 (Issue #119)

## 📋 Changements

### Nouveau système de phases
- **4 phases** au lieu de 6 : `waiting_attack_roll`, `waiting_damage_roll`, `turn_complete`, `ended`
- **currentTurn explicite** : `'player' | 'enemy'` (remplace le tracking implicite par phase)
- **Transitions plus claires** basées sur hit/miss

### Implémentation
- ✅ `PhaseManagerV3` : Logique de phases et alternance des tours
- ✅ `CombatValidatorV3` : Actions disponibles par phase/tour
- ✅ `CombatPhaseV3` : Nouvel enum de phases + type CurrentTurn
- ✅ `CombatStateV3` : Nouvelle interface d'état avec currentTurn

### Compatibilité
- ✅ `WeaponAbilityResolver` rendu générique (supporte V2 et V3)
- ✅ Export des types V3 sans breaking changes
- ✅ Tous les 701 tests existants passent

### Tests
- ✅ **PhaseManagerV3** : 18 tests (transitions, alternance, incrémentation)
- ✅ **CombatValidatorV3** : 15 tests (actions, triggers, fin de combat)
- ✅ **Total** : 701 tests passent

### Documentation
- ✅ `docs/COMBAT_V3.md` : Guide complet du système V3

## 🔗 Liens

- Closes #119
- Epic #115

## ✅ Checklist

- [x] Tests unitaires ajoutés (33 nouveaux tests)
- [x] Documentation mise à jour
- [x] Tous les tests passent (701/701)
- [x] Lint sans erreur sur les nouveaux fichiers
- [x] Aucun breaking change (V2 toujours fonctionnel)
