### PR TITLE
feat(combat-v3): add combat history tracking system (Issue #120)

### DIFF
--- a/src/domain/services/combat/AttackResolver.ts
+++ b/src/domain/services/combat/AttackResolver.ts
@@ -7,6 +7,8 @@ import { PhaseManager } from './PhaseManager';
 import { CombatEventType } from '../../types/CombatEventType';
 import { WeaponAbilityResolver } from './WeaponAbilityResolver';
 import { WeaponAbilityTrigger } from '../../types/WeaponAbilityTrigger';
+import { HistoryManager } from './HistoryManager';
+import { CombatActionType } from '../../types/CombatActionType';
 
 export interface ActionResolutionResult {
   state: CombatState;
@@ -21,6 +23,9 @@ export class AttackResolver {
     const isPlayerAttacking = state.phase === CombatPhase.PLAYER_TURN;
     const attacker = isPlayerAttacking ? state.player : state.enemy;
     const dexterite = attacker.dexterite;
+
+    // Capture HP avant l'action
+    const hpBefore = HistoryManager.createHPSnapshot(state);
 
     const diceRoll = DiceRoller.rollHitDice(diceOverrides?.hitDice);
     const hit = diceRoll.total <= dexterite;
@@ -65,9 +70,14 @@ export class AttackResolver {
       newState.phase = CombatPhase.ENEMY_ATTACK;
     }
 
+    let damageDealt = 0;
+    let damageDiceRolled = 0;
+
     if (hit) {
       const attackerBonus = isPlayerAttacking ? newState.player.totalDamageBonus : attacker.totalDamageBonus;
-      const damage = DiceRoller.calculateDamage(attackerBonus, diceOverrides?.damageDice);
+      damageDiceRolled = DiceRoller.rollDamageDice(diceOverrides?.damageDice);
+      const damage = 1 + damageDiceRolled + attackerBonus;
+      damageDealt = damage;
 
       if (isPlayerAttacking) {
         const targetEnemy = newState.enemy;
@@ -124,6 +134,37 @@ export class AttackResolver {
       // Note: ON_MISS abilities (like Arc des Vents) are NOT auto-resolved.
       // They are detected by CombatValidator and made available as manual actions.
     }
+
+    // Capture HP après l'action
+    const hpAfter = HistoryManager.createHPSnapshot(newState);
+
+    // Enregistrer dans l'historique
+    const historyEntry = {
+      round: state.roundNumber,
+      turn: isPlayerAttacking ? Attacker.PLAYER : Attacker.ENEMY,
+      action: CombatActionType.ATTACK,
+      hitRoll: HistoryManager.createHitRollDetails(
+        { ...diceRoll, success: hit },
+        dexterite
+      ),
+      damageRoll: hit
+        ? HistoryManager.createDamageRollDetails(
+            damageDiceRolled,
+            isPlayerAttacking ? state.player.totalDamageBonus : attacker.totalDamageBonus,
+            damageDealt
+          )
+        : undefined,
+      hpBefore,
+      hpAfter,
+      timestamp: new Date().toISOString(),
+      description: HistoryManager.generateAttackDescription(
+        isPlayerAttacking ? Attacker.PLAYER : Attacker.ENEMY,
+        hit,
+        hit ? damageDealt : undefined
+      ),
+    };
+
+    newState.history = HistoryManager.addEntry(newState, historyEntry);
 
     return { state: newState, events };
   }

--- a/src/domain/services/combat/CombatEngine.ts
+++ b/src/domain/services/combat/CombatEngine.ts
@@ -69,6 +69,7 @@ export class CombatEngine {
       usedReroll: false,
       isFirstAttack: true,
       usedItems: [],
+      history: [],
       events: [
         {
           type: CombatEventType.COMBAT_START,

--- a/src/domain/services/combat/HistoryManager.ts
+++ b/src/domain/services/combat/HistoryManager.ts
@@ -1,0 +1,159 @@
+import type {
+  CombatHistoryEntry,
+  HitRollDetails,
+  DamageRollDetails,
+  HPSnapshot,
+} from '../../types/combat-history';
+import type { CombatState } from '../../types/combat-v2';
+import type { CombatActionType } from '../../types/CombatActionType';
+import type { Attacker } from '../../types/Attacker';
+import type { DiceRoll } from '../../types/combatants';
+
+export class HistoryManager {
+  /**
+   * Génère un ID unique pour une entrée d'historique
+   */
+  private static generateId(): string {
+    return `hist-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  /**
+   * Crée un snapshot des HP actuels
+   */
+  static createHPSnapshot(state: CombatState): HPSnapshot {
+    return {
+      player: state.player.endurance,
+      enemy: state.enemy.endurance,
+    };
+  }
+
+  /**
+   * Convertit un DiceRoll en HitRollDetails
+   */
+  static createHitRollDetails(
+    roll: DiceRoll,
+    target: number
+  ): HitRollDetails {
+    return {
+      dice: [roll.dice1, roll.dice2],
+      target,
+      success: roll.success ?? false,
+      total: roll.total,
+    };
+  }
+
+  /**
+   * Crée un DamageRollDetails à partir des informations de dégâts
+   */
+  static createDamageRollDetails(
+    dice: number,
+    bonus: number,
+    total: number
+  ): DamageRollDetails {
+    return {
+      dice,
+      bonus,
+      total,
+    };
+  }
+
+  /**
+   * Ajoute une entrée à l'historique du combat
+   */
+  static addEntry(
+    state: CombatState,
+    entry: Omit<CombatHistoryEntry, 'id'>
+  ): CombatHistoryEntry[] {
+    const fullEntry: CombatHistoryEntry = {
+      id: this.generateId(),
+      ...entry,
+    };
+
+    return [...state.history, fullEntry];
+  }
+
+  /**
+   * Filtre l'historique par round
+   */
+  static filterByRound(
+    history: CombatHistoryEntry[],
+    round: number
+  ): CombatHistoryEntry[] {
+    return history.filter((entry) => entry.round === round);
+  }
+
+  /**
+   * Filtre l'historique par tour (player/enemy)
+   */
+  static filterByTurn(
+    history: CombatHistoryEntry[],
+    turn: Attacker
+  ): CombatHistoryEntry[] {
+    return history.filter((entry) => entry.turn === turn);
+  }
+
+  /**
+   * Filtre l'historique par type d'action
+   */
+  static filterByAction(
+    history: CombatHistoryEntry[],
+    action: CombatActionType
+  ): CombatHistoryEntry[] {
+    return history.filter((entry) => entry.action === action);
+  }
+
+  /**
+   * Récupère la dernière entrée de l'historique
+   */
+  static getLastEntry(
+    history: CombatHistoryEntry[]
+  ): CombatHistoryEntry | undefined {
+    return history[history.length - 1];
+  }
+
+  /**
+   * Génère une description textuelle pour une attaque
+   */
+  static generateAttackDescription(
+    attacker: Attacker,
+    hit: boolean,
+    damage?: number
+  ): string {
+    const attackerName = attacker === 'player' ? 'Vous' : "L'ennemi";
+    const targetName = attacker === 'player' ? "l'ennemi" : 'vous';
+
+    if (hit && damage !== undefined) {
+      return `${attackerName} ${attacker === 'player' ? 'touchez' : 'touche'} ${targetName} et ${attacker === 'player' ? 'infligez' : 'inflige'} ${damage} dégâts`;
+    } else {
+      return `${attackerName} ${attacker === 'player' ? 'ratez' : 'rate'} ${targetName}`;
+    }
+  }
+
+  /**
+   * Génère une description pour l'utilisation d'un objet
+   */
+  static generateItemDescription(itemName: string): string {
+    return `Vous utilisez ${itemName}`;
+  }
+
+  /**
+   * Génère une description pour l'utilisation d'une capacité d'arme
+   */
+  static generateAbilityDescription(abilityName: string): string {
+    return `Vous utilisez ${abilityName}`;
+  }
+
+  /**
+   * Génère une description pour un blocage
+   */
+  static generateBlockDescription(damage: number): string {
+    return `Vous bloquez ${damage} dégâts`;
+  }
+
+  /**
+   * Génère une description pour un reroll
+   */
+  static generateRerollDescription(): string {
+    return 'Vous relancez les dés';
+  }
+}

--- a/src/domain/types/combat-history.ts
+++ b/src/domain/types/combat-history.ts
@@ -1,0 +1,67 @@
+import type { CombatActionType } from './CombatActionType';
+import type { Attacker } from './Attacker';
+
+/**
+ * Détails d'un jet d'attaque dans l'historique
+ */
+export interface HitRollDetails {
+  /** Résultat des deux dés (ex: [4, 2]) */
+  dice: [number, number];
+  /** Valeur cible (HABILETÉ du combattant) */
+  target: number;
+  /** Si le jet a réussi (total ≤ target) */
+  success: boolean;
+  /** Total du jet (dice[0] + dice[1]) */
+  total: number;
+}
+
+/**
+ * Détails d'un jet de dégâts dans l'historique
+ */
+export interface DamageRollDetails {
+  /** Résultat du dé de dégâts */
+  dice: number;
+  /** Bonus de dégâts (arme + objets) */
+  bonus: number;
+  /** Total des dégâts (1 + dice + bonus) */
+  total: number;
+}
+
+/**
+ * Points de vie avant/après une action
+ */
+export interface HPSnapshot {
+  player: number;
+  enemy: number;
+}
+
+/**
+ * Entrée complète dans l'historique du combat
+ * Contient tous les détails d'une action (jets, HP, description)
+ */
+export interface CombatHistoryEntry {
+  /** ID unique de l'entrée */
+  id: string;
+  /** Numéro du round */
+  round: number;
+  /** Tour en cours (player/enemy) */
+  turn: Attacker;
+  /** Type d'action */
+  action: CombatActionType;
+  /** Détails du jet d'attaque (si applicable) */
+  hitRoll?: HitRollDetails;
+  /** Détails du jet de dégâts (si applicable) */
+  damageRoll?: DamageRollDetails;
+  /** HP avant l'action */
+  hpBefore: HPSnapshot;
+  /** HP après l'action */
+  hpAfter: HPSnapshot;
+  /** Timestamp de l'action */
+  timestamp: string;
+  /** Description textuelle de l'action */
+  description: string;
+  /** ID de l'objet utilisé (si applicable) */
+  itemId?: string;
+  /** ID de la capacité d'arme utilisée (si applicable) */
+  abilityId?: string;
+}

--- a/src/domain/types/combat-state.ts
+++ b/src/domain/types/combat-state.ts
@@ -4,6 +4,7 @@ import type { CombatActionType } from './CombatActionType';
 import type { Attacker } from './Attacker';
 import type { PlayerState, EnemyState, DiceRoll, PendingDamage, CombatConfig } from './combatants';
 import { CombatEventType } from './CombatEventType';
+import type { CombatHistoryEntry } from './combat-history';
 
 /**
  * Item utilisé pendant le combat, à consommer à la fin
@@ -31,6 +32,8 @@ export interface CombatState {
   events: CombatEvent[];
   /** Items utilisés pendant le combat, à consommer via consumeItem() à la fin */
   usedItems: UsedItem[];
+  /** Historique détaillé du combat avec jets et HP tracking */
+  history: CombatHistoryEntry[];
 }
 
 /**
@@ -53,6 +56,8 @@ export interface CombatStateV3 {
   config: CombatConfig;
   events: CombatEvent[];
   usedItems: UsedItem[];
+  /** Historique détaillé du combat avec jets et HP tracking */
+  history: CombatHistoryEntry[];
 }
 
 export interface CombatEvent {

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -9,6 +9,14 @@ export * from './combat-v2';
 export { CombatPhaseV3, type CurrentTurn } from './CombatPhaseV3';
 export type { CombatStateV3 } from './combat-state';
 
+// Combat History types
+export type {
+  CombatHistoryEntry,
+  HitRollDetails,
+  DamageRollDetails,
+  HPSnapshot,
+} from './combat-history';
+
 // Combat constants
 export { CombatActionType } from './CombatActionType';
 export { CombatEventType } from './CombatEventType';

--- a/tests/domain/services/combat/HistoryManager.test.ts
+++ b/tests/domain/services/combat/HistoryManager.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect } from 'vitest';
+import { HistoryManager } from '@/src/domain/services/combat/HistoryManager';
+import type { CombatState } from '@/src/domain/types/combat-v2';
+import type { CombatHistoryEntry } from '@/src/domain/types/combat-history';
+import { CombatPhase } from '@/src/domain/types/CombatPhase';
+import { Attacker } from '@/src/domain/types/Attacker';
+import { CombatActionType } from '@/src/domain/types/CombatActionType';
+
+const createMockState = (playerEndurance: number, enemyEndurance: number): CombatState => ({
+  id: 'combat-1',
+  characterId: 'char-1',
+  player: {
+    name: 'Hero',
+    dexterite: 10,
+    endurance: playerEndurance,
+    enduranceMax: 20,
+    chance: 10,
+    weapon: {
+      id: 'sword',
+      name: 'Épée',
+      bonus: 2,
+    },
+    weaponDamage: 2,
+    passiveDamageBonus: 0,
+    totalDamageBonus: 2,
+  },
+  enemy: {
+    name: 'Goblin',
+    dexterite: 8,
+    endurance: enemyEndurance,
+    enduranceMax: 10,
+    weaponDamage: 0,
+    passiveDamageBonus: 0,
+    totalDamageBonus: 0,
+  },
+  phase: CombatPhase.PLAYER_TURN,
+  roundNumber: 1,
+  currentAttacker: Attacker.PLAYER,
+  config: {
+    damageFormula: '1 + 1d6 + DOMMAGES',
+    firstAttacker: Attacker.PLAYER,
+  },
+  usedAbilities: {},
+  usedReroll: false,
+  isFirstAttack: true,
+  usedItems: [],
+  history: [],
+  events: [],
+});
+
+describe('HistoryManager', () => {
+  describe('createHPSnapshot', () => {
+    it('should capture current HP from state', () => {
+      const state = createMockState(18, 12);
+      
+      const snapshot = HistoryManager.createHPSnapshot(state);
+      
+      expect(snapshot).toEqual({
+        player: 18,
+        enemy: 12,
+      });
+    });
+  });
+
+  describe('createHitRollDetails', () => {
+    it('should convert DiceRoll to HitRollDetails', () => {
+      const diceRoll = {
+        dice1: 4,
+        dice2: 2,
+        total: 6,
+        success: true,
+      };
+      
+      const details = HistoryManager.createHitRollDetails(diceRoll, 7);
+      
+      expect(details).toEqual({
+        dice: [4, 2],
+        target: 7,
+        success: true,
+        total: 6,
+      });
+    });
+
+    it('should handle failed rolls', () => {
+      const diceRoll = {
+        dice1: 5,
+        dice2: 5,
+        total: 10,
+        success: false,
+      };
+      
+      const details = HistoryManager.createHitRollDetails(diceRoll, 7);
+      
+      expect(details.success).toBe(false);
+    });
+  });
+
+  describe('createDamageRollDetails', () => {
+    it('should create damage roll details correctly', () => {
+      const details = HistoryManager.createDamageRollDetails(5, 2, 8);
+      
+      expect(details).toEqual({
+        dice: 5,
+        bonus: 2,
+        total: 8,
+      });
+    });
+  });
+
+  describe('addEntry', () => {
+    it('should add entry with generated ID', () => {
+      const state = createMockState(18, 12);
+      const entry: Omit<CombatHistoryEntry, 'id'> = {
+        round: 1,
+        turn: Attacker.PLAYER,
+        action: CombatActionType.ATTACK,
+        hpBefore: { player: 18, enemy: 12 },
+        hpAfter: { player: 18, enemy: 4 },
+        timestamp: '2026-01-20T12:00:00Z',
+        description: 'Vous touchez l\'ennemi et infligez 8 dégâts',
+      };
+      
+      const newHistory = HistoryManager.addEntry(state, entry);
+      
+      expect(newHistory).toHaveLength(1);
+      expect(newHistory[0]).toMatchObject(entry);
+      expect(newHistory[0].id).toMatch(/^hist-/);
+    });
+
+    it('should preserve chronological order', () => {
+      const state = createMockState(18, 12);
+      
+      const entry1: Omit<CombatHistoryEntry, 'id'> = {
+        round: 1,
+        turn: Attacker.PLAYER,
+        action: CombatActionType.ATTACK,
+        hpBefore: { player: 18, enemy: 12 },
+        hpAfter: { player: 18, enemy: 10 },
+        timestamp: '2026-01-20T12:00:00Z',
+        description: 'First attack',
+      };
+      
+      const history1 = HistoryManager.addEntry(state, entry1);
+      
+      const entry2: Omit<CombatHistoryEntry, 'id'> = {
+        round: 1,
+        turn: Attacker.ENEMY,
+        action: CombatActionType.ATTACK,
+        hpBefore: { player: 18, enemy: 10 },
+        hpAfter: { player: 15, enemy: 10 },
+        timestamp: '2026-01-20T12:00:01Z',
+        description: 'Enemy attack',
+      };
+      
+      const stateWithHistory = { ...state, history: history1 };
+      const newHistory = HistoryManager.addEntry(stateWithHistory, entry2);
+      
+      expect(newHistory).toHaveLength(2);
+      expect(newHistory[0].description).toBe('First attack');
+      expect(newHistory[1].description).toBe('Enemy attack');
+    });
+  });
+
+  describe('filterByRound', () => {
+    it('should filter entries by round number', () => {
+      const history: CombatHistoryEntry[] = [
+        {
+          id: 'hist-1',
+          round: 1,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 12 },
+          hpAfter: { player: 18, enemy: 10 },
+          timestamp: '2026-01-20T12:00:00Z',
+          description: 'Round 1',
+        },
+        {
+          id: 'hist-2',
+          round: 2,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 10 },
+          hpAfter: { player: 18, enemy: 5 },
+          timestamp: '2026-01-20T12:00:10Z',
+          description: 'Round 2',
+        },
+        {
+          id: 'hist-3',
+          round: 1,
+          turn: Attacker.ENEMY,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 10 },
+          hpAfter: { player: 15, enemy: 10 },
+          timestamp: '2026-01-20T12:00:05Z',
+          description: 'Round 1 enemy',
+        },
+      ];
+      
+      const round1Entries = HistoryManager.filterByRound(history, 1);
+      
+      expect(round1Entries).toHaveLength(2);
+      expect(round1Entries[0].round).toBe(1);
+      expect(round1Entries[1].round).toBe(1);
+    });
+  });
+
+  describe('filterByTurn', () => {
+    it('should filter entries by attacker', () => {
+      const history: CombatHistoryEntry[] = [
+        {
+          id: 'hist-1',
+          round: 1,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 12 },
+          hpAfter: { player: 18, enemy: 10 },
+          timestamp: '2026-01-20T12:00:00Z',
+          description: 'Player attack',
+        },
+        {
+          id: 'hist-2',
+          round: 1,
+          turn: Attacker.ENEMY,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 10 },
+          hpAfter: { player: 15, enemy: 10 },
+          timestamp: '2026-01-20T12:00:05Z',
+          description: 'Enemy attack',
+        },
+      ];
+      
+      const playerEntries = HistoryManager.filterByTurn(history, Attacker.PLAYER);
+      
+      expect(playerEntries).toHaveLength(1);
+      expect(playerEntries[0].turn).toBe(Attacker.PLAYER);
+    });
+  });
+
+  describe('filterByAction', () => {
+    it('should filter entries by action type', () => {
+      const history: CombatHistoryEntry[] = [
+        {
+          id: 'hist-1',
+          round: 1,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 12 },
+          hpAfter: { player: 18, enemy: 10 },
+          timestamp: '2026-01-20T12:00:00Z',
+          description: 'Attack',
+        },
+        {
+          id: 'hist-2',
+          round: 1,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.USE_ITEM,
+          hpBefore: { player: 15, enemy: 10 },
+          hpAfter: { player: 20, enemy: 10 },
+          timestamp: '2026-01-20T12:00:05Z',
+          description: 'Use item',
+        },
+      ];
+      
+      const attackEntries = HistoryManager.filterByAction(history, CombatActionType.ATTACK);
+      
+      expect(attackEntries).toHaveLength(1);
+      expect(attackEntries[0].action).toBe(CombatActionType.ATTACK);
+    });
+  });
+
+  describe('getLastEntry', () => {
+    it('should return last entry in history', () => {
+      const history: CombatHistoryEntry[] = [
+        {
+          id: 'hist-1',
+          round: 1,
+          turn: Attacker.PLAYER,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 12 },
+          hpAfter: { player: 18, enemy: 10 },
+          timestamp: '2026-01-20T12:00:00Z',
+          description: 'First',
+        },
+        {
+          id: 'hist-2',
+          round: 1,
+          turn: Attacker.ENEMY,
+          action: CombatActionType.ATTACK,
+          hpBefore: { player: 18, enemy: 10 },
+          hpAfter: { player: 15, enemy: 10 },
+          timestamp: '2026-01-20T12:00:05Z',
+          description: 'Last',
+        },
+      ];
+      
+      const lastEntry = HistoryManager.getLastEntry(history);
+      
+      expect(lastEntry?.description).toBe('Last');
+    });
+
+    it('should return undefined for empty history', () => {
+      const lastEntry = HistoryManager.getLastEntry([]);
+      
+      expect(lastEntry).toBeUndefined();
+    });
+  });
+
+  describe('generateAttackDescription', () => {
+    it('should generate description for successful player attack', () => {
+      const description = HistoryManager.generateAttackDescription(Attacker.PLAYER, true, 8);
+      
+      expect(description).toBe('Vous touchez l\'ennemi et infligez 8 dégâts');
+    });
+
+    it('should generate description for missed player attack', () => {
+      const description = HistoryManager.generateAttackDescription(Attacker.PLAYER, false);
+      
+      expect(description).toBe('Vous ratez l\'ennemi');
+    });
+
+    it('should generate description for successful enemy attack', () => {
+      const description = HistoryManager.generateAttackDescription(Attacker.ENEMY, true, 5);
+      
+      expect(description).toBe('L\'ennemi touche vous et inflige 5 dégâts');
+    });
+
+    it('should generate description for missed enemy attack', () => {
+      const description = HistoryManager.generateAttackDescription(Attacker.ENEMY, false);
+      
+      expect(description).toBe('L\'ennemi rate vous');
+    });
+  });
+
+  describe('generateItemDescription', () => {
+    it('should generate item usage description', () => {
+      const description = HistoryManager.generateItemDescription('Potion de soin');
+      
+      expect(description).toBe('Vous utilisez Potion de soin');
+    });
+  });
+
+  describe('generateAbilityDescription', () => {
+    it('should generate ability usage description', () => {
+      const description = HistoryManager.generateAbilityDescription('Attaque éclair');
+      
+      expect(description).toBe('Vous utilisez Attaque éclair');
+    });
+  });
+
+  describe('generateBlockDescription', () => {
+    it('should generate block description', () => {
+      const description = HistoryManager.generateBlockDescription(6);
+      
+      expect(description).toBe('Vous bloquez 6 dégâts');
+    });
+  });
+
+  describe('generateRerollDescription', () => {
+    it('should generate reroll description', () => {
+      const description = HistoryManager.generateRerollDescription();
+      
+      expect(description).toBe('Vous relancez les dés');
+    });
+  });
+});

--- a/tests/domain/services/combat/history-integration.test.ts
+++ b/tests/domain/services/combat/history-integration.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { CombatEngine } from '@/src/domain/services/combat/CombatEngine';
+import { CombatActionType } from '@/src/domain/types/CombatActionType';
+import { CombatPhase } from '@/src/domain/types/CombatPhase';
+import { Attacker } from '@/src/domain/types/Attacker';
+import type { PlayerConfig, EnemyConfig } from '@/src/domain/types/combatants';
+
+const createPlayerConfig = (): PlayerConfig => ({
+  name: 'Hero',
+  dexterite: 10,
+  endurance: 20,
+  enduranceMax: 20,
+  chance: 10,
+  weapon: {
+    id: 'sword',
+    name: 'Épée',
+    bonus: 2,
+  },
+});
+
+const createEnemyConfig = (): EnemyConfig => ({
+  name: 'Goblin',
+  dexterite: 8,
+  endurance: 12,
+  enduranceMax: 12,
+});
+
+describe('Combat History Integration', () => {
+  describe('Attack sequence recording', () => {
+    it('should record complete attack with hit roll details', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // Simulate successful hit: 4 + 2 = 6 ≤ 10
+      const result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [4, 2], damageDice: 5 }
+      );
+      state = result.state;
+
+      expect(state.history).toHaveLength(1);
+      const entry = state.history[0];
+
+      expect(entry.round).toBe(1);
+      expect(entry.turn).toBe(Attacker.PLAYER);
+      expect(entry.action).toBe(CombatActionType.ATTACK);
+      expect(entry.hitRoll).toEqual({
+        dice: [4, 2],
+        target: 10,
+        success: true,
+        total: 6,
+      });
+      expect(entry.damageRoll).toEqual({
+        dice: 5,
+        bonus: 2,
+        total: 8, // 1 + 5 + 2
+      });
+      expect(entry.hpBefore).toEqual({ player: 20, enemy: 12 });
+      expect(entry.hpAfter).toEqual({ player: 20, enemy: 4 });
+      expect(entry.description).toContain('infligez 8 dégâts');
+    });
+
+    it('should record missed attack without damage roll', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // Simulate miss: 5 + 6 = 11 > 10
+      const result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [5, 6] }
+      );
+      state = result.state;
+
+      expect(state.history).toHaveLength(1);
+      const entry = state.history[0];
+
+      expect(entry.hitRoll).toEqual({
+        dice: [5, 6],
+        target: 10,
+        success: false,
+        total: 11,
+      });
+      expect(entry.damageRoll).toBeUndefined();
+      expect(entry.hpBefore).toEqual(entry.hpAfter);
+      expect(entry.description).toContain('ratez');
+    });
+
+    it('should track HP before and after each action', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // First attack
+      const result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [3, 3], damageDice: 4 }
+      );
+      state = result.state;
+
+      expect(state.history[0].hpBefore).toEqual({ player: 20, enemy: 12 });
+      expect(state.history[0].hpAfter).toEqual({ player: 20, enemy: 5 }); // 12 - 7 (1+4+2)
+    });
+
+    it('should preserve chronological order in history', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // First player attack
+      let result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [3, 3], damageDice: 2 }
+      );
+      state = result.state;
+
+      const firstTimestamp = state.history[0].timestamp;
+
+      // Simulate time passing
+      const delay = 100;
+      const startTime = Date.now();
+      while (Date.now() - startTime < delay) {
+        // busy wait
+      }
+
+      // Second player attack (after advancing phase back to PLAYER_TURN)
+      state.phase = CombatPhase.PLAYER_TURN;
+      state.roundNumber = 2;
+      result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [4, 3], damageDice: 3 }
+      );
+      state = result.state;
+
+      // Verify chronological order and timestamps
+      expect(state.history).toHaveLength(2);
+      expect(state.history[0].round).toBe(1);
+      expect(state.history[1].round).toBe(2);
+      expect(new Date(state.history[1].timestamp).getTime()).toBeGreaterThan(
+        new Date(firstTimestamp).getTime()
+      );
+    });
+  });
+
+  describe('History with weapon abilities', () => {
+    it('should record weapon ability activation', () => {
+      const player: PlayerConfig = {
+        ...createPlayerConfig(),
+        weapon: {
+          id: 'legendary-sword',
+          name: 'Épée Légendaire',
+          bonus: 3,
+          ability: {
+            id: 'extra-attack',
+            name: 'Attaque supplémentaire',
+            trigger: 'on_double',
+            effect: { type: 'extra_attack' },
+            usesPerCombat: 1,
+          },
+        },
+      };
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // Attack with double
+      const result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [3, 3], damageDice: 4 }
+      );
+      state = result.state;
+
+      // Should have attack entry
+      expect(state.history).toHaveLength(1);
+      expect(state.history[0].action).toBe(CombatActionType.ATTACK);
+    });
+  });
+
+  describe('Multiple rounds tracking', () => {
+    it('should track multiple rounds in history', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      let state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      // Round 1
+      let result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [3, 3], damageDice: 2 }
+      );
+      state = result.state;
+
+      expect(state.history[0].round).toBe(1);
+
+      // Advance to round 2
+      state.roundNumber = 2;
+      state.phase = CombatPhase.PLAYER_TURN;
+      
+      result = CombatEngine.resolve(
+        state,
+        { type: CombatActionType.ATTACK },
+        { hitDice: [4, 2], damageDice: 3 }
+      );
+      state = result.state;
+
+      expect(state.history).toHaveLength(2);
+      expect(state.history[0].round).toBe(1);
+      expect(state.history[1].round).toBe(2);
+    });
+  });
+
+  describe('History initial state', () => {
+    it('should initialize with empty history', () => {
+      const player = createPlayerConfig();
+      const enemy = createEnemyConfig();
+
+      const state = CombatEngine.createInitialState('char-1', player, enemy, {
+        damageFormula: '1 + 1d6 + DOMMAGES',
+        firstAttacker: Attacker.PLAYER,
+      });
+
+      expect(state.history).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Description

Implémente le système d'historique détaillé du combat pour tracer tous les événements avec jets de dés complets et suivi des HP.

## 🎯 Issue

Closes #120

## ✅ Changements

### Types
- ✅ Créé `CombatHistoryEntry` avec tous les détails (jets, HP, description)
- ✅ Créé `HitRollDetails`, `DamageRollDetails`, `HPSnapshot`
- ✅ Ajouté `history: CombatHistoryEntry[]` dans `CombatState` et `CombatStateV3`

### Services
- ✅ Créé `HistoryManager` avec méthodes utilitaires :
  - `createHPSnapshot()` - Capture HP avant/après
  - `createHitRollDetails()` - Convertit DiceRoll en détails
  - `addEntry()` - Ajoute une entrée avec ID unique
  - `filterByRound/Turn/Action()` - Filtres utilitaires
  - `generateXDescription()` - Descriptions textuelles
- ✅ Intégré dans `AttackResolver` pour enregistrer chaque attaque
- ✅ Initialisé dans `CombatEngine.createInitialState()`

### Tests
- ✅ 19 tests unitaires pour `HistoryManager`
- ✅ 7 tests d'intégration pour l'enregistrement complet
- ✅ Tous les tests passent (727 tests au total)
- ✅ Lint passe sans erreur (0 error, 1 warning préexistant)

## 📊 Couverture

- Création de snapshots HP ✅
- Conversion de jets de dés ✅
- Filtrage par round/tour/action ✅
- Ordre chronologique préservé ✅
- Descriptions textuelles générées ✅
- Intégration complète avec AttackResolver ✅

## 🔗 Note sur le build

Le build échoue sur `DiceAnimation3D.tsx` mais ce problème existait déjà sur la branche `epic/combatV3` (non lié à cette PR).

## 🧪 Tests

```bash
pnpm test tests/domain/services/combat/HistoryManager.test.ts --run
pnpm test tests/domain/services/combat/history-integration.test.ts --run
pnpm lint
```

Tous passent ✅