### PR TITLE
feat(combat): Fix damage formula, history integration, and E2E tests (#138)

### DIFF
--- a/src/domain/services/combat/AttackResolver.ts
+++ b/src/domain/services/combat/AttackResolver.ts
@@ -1,7 +1,6 @@
 import type { CombatState, CombatEvent } from '../../types/combat-v2';
 import type { CombatStateV3 } from '../../types/combat-state';
 import { CombatPhase } from '../../types/CombatPhase';
-import { CombatPhaseV3 } from '../../types/CombatPhaseV3';
 import { Attacker } from '../../types/Attacker';
 import type { DiceOverrides } from './DiceRoller';
 import { DiceRoller } from './DiceRoller';
@@ -23,7 +22,7 @@ export interface ActionResolutionResultV3 {
 }
 
 // Type guard to check if state is V3
-function isStateV3(state: any): state is CombatStateV3 {
+function isStateV3(state: CombatState | CombatStateV3): state is CombatStateV3 {
   return 'currentTurn' in state && typeof state.currentTurn === 'string';
 }
 
@@ -213,7 +212,7 @@ export class AttackResolver {
     const dexterite = attacker.dexterite;
 
     // Capture HP avant l'action
-    const hpBefore = HistoryManager.createHPSnapshot(state as any);
+    const hpBefore = HistoryManager.createHPSnapshot(state as CombatState);
 
     const diceRoll = DiceRoller.rollHitDice(diceOverrides?.hitDice);
     const hit = diceRoll.total <= dexterite;
@@ -224,12 +223,12 @@ export class AttackResolver {
     // Check for ON_SURPRISE ability BEFORE attack (first attack only)
     if (isPlayerAttacking && newState.isFirstAttack) {
       const surpriseAbility = WeaponAbilityResolver.checkAutoTrigger(
-        newState as any,
+        newState as CombatState,
         WeaponAbilityTrigger.ON_SURPRISE,
         {}
       );
       if (surpriseAbility) {
-        const surpriseResult = WeaponAbilityResolver.resolveAbility(newState as any, surpriseAbility.id);
+        const surpriseResult = WeaponAbilityResolver.resolveAbility(newState as CombatState, surpriseAbility.id);
         // Copy back changed fields from V2 result
         newState.player = surpriseResult.state.player;
         newState.enemy = surpriseResult.state.enemy;
@@ -281,12 +280,12 @@ export class AttackResolver {
       // Check for weapon abilities on successful attack
       if (isPlayerAttacking && newState.lastRoll?.isDouble) {
         const doubleAbility = WeaponAbilityResolver.checkAutoTrigger(
-          newState as any,
+          newState as CombatState,
           WeaponAbilityTrigger.ON_DOUBLE,
           { roll: newState.lastRoll }
         );
         if (doubleAbility) {
-          const doubleResult = WeaponAbilityResolver.resolveAbility(newState as any, doubleAbility.id);
+          const doubleResult = WeaponAbilityResolver.resolveAbility(newState as CombatState, doubleAbility.id);
           newState.player = doubleResult.state.player;
           newState.enemy = doubleResult.state.enemy;
           newState.usedAbilities = doubleResult.state.usedAbilities;
@@ -297,12 +296,12 @@ export class AttackResolver {
       // Check for ON_KILL ability if enemy was defeated
       if (isPlayerAttacking && newState.enemy.endurance <= 0) {
         const killAbility = WeaponAbilityResolver.checkAutoTrigger(
-          newState as any,
+          newState as CombatState,
           WeaponAbilityTrigger.ON_KILL,
           {}
         );
         if (killAbility) {
-          const killResult = WeaponAbilityResolver.resolveAbility(newState as any, killAbility.id);
+          const killResult = WeaponAbilityResolver.resolveAbility(newState as CombatState, killAbility.id);
           newState.player = killResult.state.player;
           newState.enemy = killResult.state.enemy;
           newState.usedAbilities = killResult.state.usedAbilities;
@@ -312,7 +311,7 @@ export class AttackResolver {
     }
 
     // Capture HP après l'action
-    const hpAfter = HistoryManager.createHPSnapshot(newState as any);
+    const hpAfter = HistoryManager.createHPSnapshot(newState as CombatState);
 
     // Enregistrer dans l'historique
     const historyEntry = {
@@ -325,7 +324,7 @@ export class AttackResolver {
       ),
       damageRoll: hit
         ? HistoryManager.createDamageRollDetails(
-            { total: diceRoll.total, dice1: diceRoll.dice1 } as any,
+            { total: diceRoll.total, dice1: diceRoll.dice1, dice2: 0 },
             isPlayerAttacking ? state.player.totalDamageBonus : 0,
             hit ? Math.max(0, diceRoll.total + (isPlayerAttacking ? state.player.totalDamageBonus : 0)) : 0
           )
@@ -340,7 +339,7 @@ export class AttackResolver {
       ),
     };
 
-    newState.history = HistoryManager.addEntry(newState as any, historyEntry);
+    newState.history = HistoryManager.addEntry(newState as CombatState, historyEntry);
 
     return { state: newState, events };
   }

--- a/src/domain/services/combat/CombatEngine.ts
+++ b/src/domain/services/combat/CombatEngine.ts
@@ -14,6 +14,7 @@ import { ItemResolver, type CombatUsableItem } from './ItemResolver';
 import { WeaponAbilityResolver } from './WeaponAbilityResolver';
 import { PhaseManager } from './PhaseManager';
 import { CombatValidator } from './CombatValidator';
+import { HistoryManager } from './HistoryManager';
 
 export type CombatResult = {
   state: CombatState;
@@ -61,7 +62,7 @@ export class CombatEngine {
       },
       enemy: {
         ...enemy,
-        endurance: enemy.enduranceMax,
+        endurance: enemy.endurance ?? enemy.enduranceMax,
         weaponDamage: 0,
         passiveDamageBonus: 0,
         totalDamageBonus: enemyTotalDamageBonus,
@@ -140,6 +141,9 @@ export class CombatEngine {
     const attacker = isPlayerAttacking ? state.player : state.enemy;
     const dexterite = attacker.dexterite;
 
+    // Capture HP before action
+    const hpBefore = HistoryManager.createHPSnapshot(state);
+
     // Simuler le DiceRoller pour les tests avec des overrides simples
     const dice1 = diceOverrides?.hitDice?.[0] ?? Math.floor(Math.random() * 6) + 1;
     const dice2 = diceOverrides?.hitDice?.[1] ?? Math.floor(Math.random() * 6) + 1;
@@ -172,14 +176,17 @@ export class CombatEngine {
       isDouble: dice1 === dice2,
     };
 
+    let damageDealt = 0;
+    let damageDice = 0;
+
     if (hit) {
-      // Calculate and apply damage (V3 formule: dice + bonus, pas de +1)
-      const damageDice = diceOverrides?.damageDice ?? Math.floor(Math.random() * 6) + 1;
+      // Calculate and apply damage (formule officielle: 1 + 1d6 + DOMMAGES ACTUELS)
+      damageDice = diceOverrides?.damageDice ?? Math.floor(Math.random() * 6) + 1;
       const totalDamageBonus = isPlayerAttacking ? state.player.totalDamageBonus : 0; // Enemy has no weapons
-      const damageDealt = damageDice + totalDamageBonus;
+      damageDealt = 1 + damageDice + totalDamageBonus; // Formule officielle
 
       events.push({
-        type: CombatEventType.DAMAGE_ROLL,
+        type: CombatEventType.DAMAGE_DEALT,
         timestamp: new Date().toISOString(),
         round: state.roundNumber,
         attacker: isPlayerAttacking ? Attacker.PLAYER : Attacker.ENEMY,
@@ -193,6 +200,9 @@ export class CombatEngine {
         newState.player.endurance = Math.max(0, newState.player.endurance - damageDealt);
       }
     }
+
+    // Capture HP after action
+    const hpAfter = HistoryManager.createHPSnapshot(newState);
 
     // Check if combat ended
     const combatEnded = CombatValidator.checkCombatEnd(newState) !== 'ongoing';
@@ -208,12 +218,39 @@ export class CombatEngine {
         { combatEnded }
       );
     }
-    
+
+    // Add history entry
+    const historyEntry = {
+      round: state.roundNumber,
+      turn: isPlayerAttacking ? Attacker.PLAYER : Attacker.ENEMY,
+      action: CombatActionType.ATTACK,
+      hitRoll: HistoryManager.createHitRollDetails(
+        { dice1, dice2, total, success: hit, isDouble: dice1 === dice2 },
+        dexterite
+      ),
+      damageRoll: hit
+        ? HistoryManager.createDamageRollDetails(
+            damageDice,
+            isPlayerAttacking ? state.player.totalDamageBonus : 0,
+            damageDealt
+          )
+        : undefined,
+      hpBefore,
+      hpAfter,
+      timestamp: new Date().toISOString(),
+      description: HistoryManager.generateAttackDescription(
+        isPlayerAttacking ? Attacker.PLAYER : Attacker.ENEMY,
+        hit,
+        hit ? damageDealt : undefined
+      ),
+    };
+
     const finalState: CombatState = {
       ...newState,
       phase: phaseUpdate.phase,
       currentTurn: phaseUpdate.currentTurn,
       roundNumber: phaseUpdate.roundNumber,
+      history: HistoryManager.addEntry(newState, historyEntry),
     };
 
     // Ajouter événement de fin si le combat est terminé
@@ -232,9 +269,20 @@ export class CombatEngine {
    * Résout un reroll (uniquement joueur)
    */
   private static resolveReroll(state: CombatState, diceOverrides?: DiceOverrides): CombatResult {
-    if (state.currentTurn !== 'player' || !state.lastRoll || state.usedReroll) {
+    // Can only reroll if: player's turn, has a last roll, hasn't used reroll, and either in WAITING_ATTACK_ROLL or TURN_COMPLETE after a miss
+    const canReroll =
+      state.currentTurn === 'player' &&
+      state.lastRoll &&
+      !state.usedReroll &&
+      (state.phase === CombatPhaseV3.WAITING_ATTACK_ROLL ||
+        (state.phase === CombatPhaseV3.TURN_COMPLETE && !state.lastRoll.success));
+
+    if (!canReroll) {
       return { state, events: [] };
     }
+
+    // Capture HP before action
+    const hpBefore = HistoryManager.createHPSnapshot(state);
 
     const dice1 = diceOverrides?.hitDice?.[0] ?? Math.floor(Math.random() * 6) + 1;
     const dice2 = diceOverrides?.hitDice?.[1] ?? Math.floor(Math.random() * 6) + 1;
@@ -252,6 +300,8 @@ export class CombatEngine {
         isDouble: dice1 === dice2,
       },
       usedReroll: true,
+      // Si on était en TURN_COMPLETE, revenir à WAITING_ATTACK_ROLL pour pouvoir continuer
+      phase: state.phase === CombatPhaseV3.TURN_COMPLETE ? CombatPhaseV3.WAITING_ATTACK_ROLL : state.phase,
     };
 
     const events: CombatEvent[] = [
@@ -265,7 +315,30 @@ export class CombatEngine {
       },
     ];
 
-    return { state: newState, events };
+    // Capture HP after action (no change for reroll)
+    const hpAfter = HistoryManager.createHPSnapshot(newState);
+
+    // Add history entry
+    const historyEntry = {
+      round: state.roundNumber,
+      turn: Attacker.PLAYER,
+      action: CombatActionType.REROLL,
+      hitRoll: HistoryManager.createHitRollDetails(
+        { dice1, dice2, total, success: hit, isDouble: dice1 === dice2 },
+        dexterite
+      ),
+      hpBefore,
+      hpAfter,
+      timestamp: new Date().toISOString(),
+      description: HistoryManager.generateRerollDescription(),
+    };
+
+    const finalState: CombatState = {
+      ...newState,
+      history: HistoryManager.addEntry(newState, historyEntry),
+    };
+
+    return { state: finalState, events };
   }
 
   /**

--- a/src/domain/services/combat/CombatValidator.ts
+++ b/src/domain/services/combat/CombatValidator.ts
@@ -58,8 +58,17 @@ export class CombatValidator {
       // Enemy damage roll est aussi automatique
     }
 
-    // TURN_COMPLETE - skip to next turn
+    // TURN_COMPLETE - skip to next turn or reroll if player missed and hasn't used reroll
     if (state.phase === CombatPhaseV3.TURN_COMPLETE) {
+      // Allow reroll if: player's turn just ended, they missed, haven't used reroll yet
+      if (
+        state.currentTurn === 'player' &&
+        state.lastRoll &&
+        !state.lastRoll.success &&
+        !state.usedReroll
+      ) {
+        actions.push({ action: { type: CombatActionType.REROLL }, enabled: true });
+      }
       actions.push({ action: { type: CombatActionType.SKIP }, enabled: true });
     }
 

--- a/src/domain/services/combat/ReactionResolver.ts
+++ b/src/domain/services/combat/ReactionResolver.ts
@@ -18,7 +18,7 @@ export interface ActionResolutionResultV3 {
 }
 
 // Type guard to check if state is V3
-function isStateV3(state: any): state is CombatStateV3 {
+function isStateV3(state: CombatState | CombatStateV3): state is CombatStateV3 {
   return 'currentTurn' in state && typeof state.currentTurn === 'string';
 }
 

--- a/src/presentation/components/combat/CombatantCard.test.tsx
+++ b/src/presentation/components/combat/CombatantCard.test.tsx
@@ -39,12 +39,6 @@ describe('CombatantCard', () => {
     isBoss: false,
   };
 
-  const bossCombatant = {
-    ...enemyCombatant,
-    name: 'Dragon',
-    isBoss: true,
-  };
-
   describe('rendering', () => {
     it('should render player combatant', () => {
       render(

--- a/tests/domain/services/combat/CombatEngine.e2e.test.ts
+++ b/tests/domain/services/combat/CombatEngine.e2e.test.ts
@@ -35,34 +35,16 @@ import {
 
 describe('CombatEngine V3 - Tests E2E Complets', () => {
   describe('Scénario 1 : Victoire rapide (Easy)', () => {
-    it('should defeat a weak goblin in 2 rounds', () => {
+    it('should defeat a weak goblin in 1 round', () => {
       const state = createTestCombat(
         TEST_PLAYERS.WARRIOR,
         TEST_ENEMIES.WEAK_GOBLIN
       );
 
-      // Round 1 : Joueur touche (2d6 = 3 ≤ 7), inflige 7 dégâts (1d6=4 + 3 bonus)
-      let newState = simulateAttack(state, [2, 1], 4);
-      assertEnemyHP(newState, 1); // 8 - 7 = 1
-      assertOngoing(newState);
-      
-      // Skip to next turn
-      const skip1 = CombatEngine.resolve(newState, { type: CombatActionType.SKIP });
-      newState = skip1.state;
-
-      // Ennemi rate (2d6 = 8 > 5)
-      newState = simulateAttack(newState, [4, 4]);
-      assertPlayerHP(newState, 32);
-      
-      const skip2 = CombatEngine.resolve(newState, { type: CombatActionType.SKIP });
-      newState = skip2.state;
-
-      // Round 2 : Joueur touche et tue
-      newState = simulateAttack(newState, [3, 2], 3);
-      
+      // Round 1 : Joueur touche (2d6 = 3 ≤ 7), inflige 8 dégâts (1 + 1d6=4 + 3 bonus)
+      const newState = simulateAttack(state, [2, 1], 4);
+      assertEnemyHP(newState, 0); // 8 - 8 = 0
       assertVictory(newState);
-      assertEnemyHP(newState, 0);
-      assertPlayerHP(newState, 32);
       assertPhase(newState, CombatPhaseV3.ENDED);
     });
   });
@@ -82,11 +64,11 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
       const skip1 = CombatEngine.resolve(newState, { type: CombatActionType.SKIP });
       newState = skip1.state;
 
-      // Troll touche (2d6 = 7 ≤ 8), inflige 6 dégâts (1d6=6 + 0 bonus ennemi)
+      // Troll touche (2d6 = 7 ≤ 8), inflige 7 dégâts (1 + 1d6=6 + 0 bonus ennemi)
       newState = simulateAttack(newState, [3, 4], 6);
       
       assertDefeat(newState);
-      assertPlayerHP(newState, 0);
+      assertPlayerHP(newState, 0); // 5 - 7 = -2, capped at 0
       assertPhase(newState, CombatPhaseV3.ENDED);
     });
   });
@@ -101,32 +83,32 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
       // Round 1 : Joueur touche, Orc touche
       let newState = simulateFullRound(
         state,
-        { hit: [3, 2], damage: 5 }, // Joueur: 5 + 3 = 8 dégâts
-        { hit: [3, 3], damage: 4 }  // Orc: 4 + 0 = 4 dégâts
+        { hit: [3, 2], damage: 5 }, // Joueur: 1 + 5 + 3 = 9 dégâts
+        { hit: [3, 3], damage: 4 }  // Orc: 1 + 4 + 0 = 5 dégâts
       );
 
-      assertPlayerHP(newState, 28); // 32 - 4
-      assertEnemyHP(newState, 12); // 20 - 8
+      assertPlayerHP(newState, 27); // 32 - 5
+      assertEnemyHP(newState, 11); // 20 - 9
       assertRound(newState, 2);
       assertOngoing(newState);
 
       // Round 2 : Joueur touche, Orc touche
       newState = simulateFullRound(
         newState,
-        { hit: [2, 3], damage: 6 }, // 6 + 3 = 9 dégâts
-        { hit: [4, 2], damage: 5 }  // 5 + 0 = 5 dégâts
+        { hit: [2, 3], damage: 6 }, // 1 + 6 + 3 = 10 dégâts
+        { hit: [4, 2], damage: 5 }  // 1 + 5 + 0 = 6 dégâts
       );
 
-      assertPlayerHP(newState, 23); // 28 - 5
-      assertEnemyHP(newState, 3);   // 12 - 9
+      assertPlayerHP(newState, 21); // 27 - 6
+      assertEnemyHP(newState, 1);   // 11 - 10
       assertRound(newState, 3);
 
       // Round 3 : Joueur finit l'Orc
-      newState = simulateAttack(newState, [3, 1], 4); // 4 + 3 = 7 dégâts
+      newState = simulateAttack(newState, [3, 1], 1); // 1 + 1 + 3 = 5 dégâts (overkill)
 
       assertVictory(newState);
       assertEnemyHP(newState, 0);
-      assertPlayerHP(newState, 23);
+      assertPlayerHP(newState, 21);
     });
   });
 
@@ -142,19 +124,19 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
 
       // Simuler 4 rounds de combat épique
       const attacks = [
-        { player: { hit: [4, 3], damage: 6 }, enemy: { hit: [5, 4], damage: 5 } }, // R1: Joueur 14 dmg, Dragon 5 dmg
-        { player: { hit: [3, 3], damage: 5 }, enemy: { hit: [4, 4], damage: 4 } }, // R2: Joueur 13 dmg, Dragon 4 dmg
-        { player: { hit: [2, 4], damage: 6 }, enemy: { hit: [6, 3], damage: 6 } }, // R3: Joueur 14 dmg, Dragon 6 dmg
-        { player: { hit: [5, 2], damage: 5 }, enemy: { hit: [5, 5] } },            // R4: Joueur 13 dmg, Dragon rate
+        { player: { hit: [4, 3], damage: 6 }, enemy: { hit: [5, 4], damage: 5 } }, // R1: Joueur 1+6+8=15 dmg, Dragon 1+5+0=6 dmg
+        { player: { hit: [3, 3], damage: 5 }, enemy: { hit: [4, 4], damage: 4 } }, // R2: Joueur 1+5+8=14 dmg, Dragon 1+4+0=5 dmg
+        { player: { hit: [2, 4], damage: 6 }, enemy: { hit: [6, 3], damage: 6 } }, // R3: Joueur 1+6+8=15 dmg, Dragon 1+6+0=7 dmg
+        { player: { hit: [5, 2], damage: 5 }, enemy: { hit: [5, 5] } },            // R4: Joueur 1+5+8=14 dmg, Dragon rate
       ];
 
       const newState = simulateUntilEnd(state, attacks, 4);
 
-      // Joueur: 50 - (5 + 4 + 6) = 35 HP
-      // Dragon: 50 - (14 + 13 + 14 + 13) = -4 HP
+      // Joueur: 50 - (6 + 5 + 7) = 32 HP
+      // Dragon: 50 - (15 + 14 + 15 + 14) = -8 HP
       assertVictory(newState);
       assertEnemyHP(newState, 0);
-      assertPlayerHP(newState, 35);
+      assertPlayerHP(newState, 32);
     });
   });
 
@@ -170,8 +152,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
       assertPhase(state, CombatPhaseV3.WAITING_ATTACK_ROLL);
 
       // Ennemi attaque en premier
-      let newState = simulateAttack(state, [2, 3], 4); // Touche, 4 dégâts
-      assertPlayerHP(newState, 28); // 32 - 4
+      let newState = simulateAttack(state, [2, 3], 4); // Touche, 1 + 4 + 0 = 5 dégâts
+      assertPlayerHP(newState, 27); // 32 - 5
       
       const skip = CombatEngine.resolve(newState, { type: CombatActionType.SKIP });
       newState = skip.state;
@@ -179,8 +161,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
       assertCurrentTurn(newState, 'player');
       
       // Joueur contre-attaque
-      newState = simulateAttack(newState, [3, 2], 5); // 5 + 3 = 8 dégâts
-      assertEnemyHP(newState, 7); // 15 - 8
+      newState = simulateAttack(newState, [3, 2], 5); // 1 + 5 + 3 = 9 dégâts
+      assertEnemyHP(newState, 6); // 15 - 9
     });
   });
 
@@ -194,8 +176,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
       expect(state.player.weapon.bonus).toBe(8);
       expect(state.player.totalDamageBonus).toBe(8);
 
-      const newState = simulateAttack(state, [3, 2], 4); // 4 + 8 = 12 dégâts
-      assertEnemyHP(newState, 3); // 15 - 12
+      const newState = simulateAttack(state, [3, 2], 4); // 1 + 4 + 8 = 13 dégâts
+      assertEnemyHP(newState, 2); // 15 - 13
     });
 
     it('should apply Durandal damage bonus (+6)', () => {
@@ -206,8 +188,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
 
       expect(state.player.totalDamageBonus).toBe(6);
 
-      const newState = simulateAttack(state, [2, 3], 5); // 5 + 6 = 11 dégâts
-      assertEnemyHP(newState, 4); // 15 - 11
+      const newState = simulateAttack(state, [2, 3], 5); // 1 + 5 + 6 = 12 dégâts
+      assertEnemyHP(newState, 3); // 15 - 12
     });
 
     it('should apply Fragarach damage bonus (+7)', () => {
@@ -218,8 +200,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
 
       expect(state.player.totalDamageBonus).toBe(7);
 
-      const newState = simulateAttack(state, [4, 2], 3); // 3 + 7 = 10 dégâts
-      assertEnemyHP(newState, 10); // 20 - 10
+      const newState = simulateAttack(state, [4, 2], 3); // 1 + 3 + 7 = 11 dégâts
+      assertEnemyHP(newState, 9); // 20 - 11
     });
   });
 
@@ -405,9 +387,9 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
 
       const result = CombatEngine.resolve(state, { type: CombatActionType.ATTACK }, { hitDice: [3, 2], damageDice: 5 });
 
-      expect(result.events).toHaveLength(2); // ATTACK_ROLL + DAMAGE_ROLL
+      expect(result.events).toHaveLength(2); // ATTACK_ROLL + DAMAGE_DEALT
       expect(result.events[0].type).toBe('attack_roll');
-      expect(result.events[1].type).toBe('damage_roll');
+      expect(result.events[1]?.type).toBe('damage_dealt');
     });
 
     it('should handle multiple rounds without errors', () => {
@@ -435,8 +417,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
         TEST_ENEMIES.GOBLIN
       );
 
-      const newState = simulateAttack(state, [3, 2], 3); // dice=3, bonus=4, total=7
-      assertEnemyHP(newState, 8); // 15 - 7
+      const newState = simulateAttack(state, [3, 2], 3); // 1 + 3 + 4 = 8 dégâts
+      assertEnemyHP(newState, 7); // 15 - 8
     });
 
     it('should calculate enemy damage correctly (base + dice, no weapon)', () => {
@@ -446,8 +428,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
         { firstAttacker: 'enemy' }
       );
 
-      const newState = simulateAttack(state, [3, 2], 5); // dice=5, no bonus, total=5
-      assertPlayerHP(newState, 27); // 32 - 5
+      const newState = simulateAttack(state, [3, 2], 5); // 1 + 5 + 0 = 6 dégâts
+      assertPlayerHP(newState, 26); // 32 - 6
     });
 
     it('should not allow negative HP', () => {
@@ -456,8 +438,8 @@ describe('CombatEngine V3 - Tests E2E Complets', () => {
         { endurance: 2, enduranceMax: 15 }
       );
 
-      const newState = simulateAttack(state, [2, 3], 6); // 6 + 3 = 9 dégâts > 2 HP
-      assertEnemyHP(newState, 0); // Capped at 0, not -7
+      const newState = simulateAttack(state, [2, 3], 6); // 1 + 6 + 3 = 10 dégâts > 2 HP
+      assertEnemyHP(newState, 0); // Capped at 0, not -8
     });
   });
 });

--- a/tests/domain/services/combat/CombatEngine.test.ts
+++ b/tests/domain/services/combat/CombatEngine.test.ts
@@ -343,7 +343,7 @@ describe('CombatEngine', () => {
 
       const result = CombatEngine.resolve(
         state,
-        { type: 'UNKNOWN_ACTION' as any }
+        { type: 'UNKNOWN_ACTION' as CombatActionType }
       );
 
       expect(result.state).toEqual(state);


### PR DESCRIPTION
## 🎯 Objectif

Première partie de la migration complète Combat V3 (#138) : correction de la formule de dégâts, intégration de l'historique, et nettoyage des erreurs de lint.

## ✅ Changements réalisés

### 1. **Formule de dégâts corrigée** ✅
- **Avant** : `damageDice + totalDamageBonus`
- **Après** : `1 + damageDice + totalDamageBonus` (formule officielle selon docs/COMBAT.md)
- Mise à jour de tous les tests E2E avec les nouvelles valeurs de dégâts

### 2. **Intégration HistoryManager** ✅
- Ajout de l'historique dans `CombatEngine.resolveAttack`
- Ajout de l'historique dans `CombatEngine.resolveReroll`
- Capture HP before/after, hitRoll, damageRoll, descriptions

### 3. **Fix TypeScript any types** ✅
- **AttackResolver.ts** : 11 any → types stricts (CombatState | CombatStateV3)
- **ReactionResolver.ts** : 1 any → type strict
- **CombatEngine.test.ts** : 1 any → CombatActionType cast
- **CombatantCard.test.tsx** : Suppression de `bossCombatant` non utilisé

### 4. **Fix bug enemy endurance** ✅
- **Avant** : `endurance: enemy.enduranceMax` (écrasait toujours)
- **Après** : `endurance: enemy.endurance ?? enemy.enduranceMax`

### 5. **Support REROLL amélioré** ✅
- REROLL disponible en phase `TURN_COMPLETE` si le joueur vient de rater
- `CombatValidator.getAvailableActions` retourne REROLL si conditions réunies
- `resolveReroll` accepte TURN_COMPLETE et revient à WAITING_ATTACK_ROLL

### 6. **Fix event type** ✅
- Utilisation de `CombatEventType.DAMAGE_DEALT` au lieu de l'inexistant `DAMAGE_ROLL`

## 🧪 Tests

### Tests E2E Combat (22/22 ✅)
```
✓ should defeat a weak goblin in 1 round
✓ should lose against a troll with low HP
✓ should win a close combat against an Orc
✓ should defeat a dragon with legendary weapon Excalibur
✓ should handle enemy attacking first (surprise)
✓ should apply Excalibur damage bonus (+8)
✓ should apply Durandal damage bonus (+6)
✓ should apply Fragarach damage bonus (+7)
✓ should handle simultaneous death (both HP reach 0)
✓ should not allow actions after combat ended
✓ should handle exactly 0 HP as defeat/victory
✓ should respect firstAttacker configuration
✓ should increment round after both turns complete
✓ should handle missed attacks without damage
✓ should allow reroll on missed attack
✓ should not allow reroll twice in same combat
✓ should maintain correct phase transitions
✓ should track events correctly
✓ should handle multiple rounds without errors
✓ should calculate player damage correctly (base + dice + weapon)
✓ should calculate enemy damage correctly (base + dice, no weapon)
✓ should not allow negative HP
```

### Lint
```
✅ 0 errors, 0 warnings
```

## 📋 Reste à faire (PR suivante)

Cette PR est **partielle**. Les tâches restantes de #138 :

- [ ] Supprimer fichiers V2 legacy (CombatPhase.ts V2)
- [ ] Renommer CombatPhaseV3 → CombatPhase
- [ ] Mettre à jour tous les imports
- [ ] Adapter combatSlice
- [ ] Adapter composants UI
- [ ] Fix tests history-integration (incompatibles V2)
- [ ] Ajouter tests manquants (items, weapon abilities, etc.)

## 🔗 Related

- Epic: #115 (Combat V3)
- Issue: #138
- Dépendances: #135 ✅, #121 ✅