### PR TITLE
fix(combat): correct HP persistence after combat victory

### DIFF
--- a/src/presentation/stores/slices/combatSlice.ts
+++ b/src/presentation/stores/slices/combatSlice.ts
@@ -392,13 +392,13 @@ export const createCombatSlice = (): StateCreator<
         const { combat, privateInitialChance } = get();
         if (!combat) return;
 
-        const damageTaken = combat.player.enduranceMax - combat.player.endurance;
         const chanceUsed = privateInitialChance - combat.player.chance;
         const characterId = combat.characterId;
 
-        if (damageTaken > 0) {
-          await get().applyDamage(characterId, damageTaken);
-        }
+        // Sync HP directly with combat state (Combat V3 applies damage immediately)
+        await get().updateStats(characterId, {
+          pointsDeVieActuels: combat.player.endurance
+        });
 
         if (chanceUsed > 0) {
           await get().updateStats(characterId, {

--- a/tests/integration/combat-v2-e2e.test.ts
+++ b/tests/integration/combat-v2-e2e.test.ts
@@ -27,7 +27,7 @@ import type { EnemyConfig } from '@/src/domain/types/combatants';
 
 type MockStoreState = CombatSlice & {
   characters: Record<string, Character>;
-  updateStats: (id: string, stats: Partial<{ chance: number }>) => Promise<void>;
+  updateStats: (id: string, stats: Partial<{ chance: number; pointsDeVieActuels: number }>) => Promise<void>;
   applyDamage: (id: string, amount: number) => Promise<void>;
   consumeItem: (id: string, itemIndex: number) => Promise<void>;
   getItem: (itemId: string) => import('@/src/domain/types/items').CatalogItem | undefined;
@@ -374,6 +374,50 @@ describe('Combat V2 - End to End Integration Tests', () => {
 
       const finalPv = currentState.combat?.player.endurance ?? 0;
       expect(finalPv).toBeLessThan(initialPv);
+    });
+
+    it('should persist correct HP after victory with damage taken (bug #152)', async () => {
+      // Bug #152: PV à 0 après victoire - double application des dégâts
+      const initialPv = 30;
+      slice.startCombat('test-char-id', mockEnemy, defaultConfig);
+
+      // Player attacks and hits enemy
+      slice.executeAction({ type: CombatActionType.ATTACK }, { hitDice: [2, 2], damageDice: 4 });
+
+      // Skip to enemy turn
+      slice.executeAction({ type: CombatActionType.SKIP });
+
+      // Enemy attacks and deals damage to player (simulated with dice override)
+      // Enemy has dexterity 6, player has dexterity 7
+      // Roll 2+2=4, which hits (4 <= 6), damage = 1 + 4 + 0 (no weapon) = 5
+      slice.executeAction({ type: CombatActionType.ATTACK }, { hitDice: [2, 2], damageDice: 4 });
+
+      const hpAfterEnemyAttack = currentState.combat?.player.endurance ?? initialPv;
+      const expectedDamage = 1 + 4; // base 1 + dice 4 (enemy has no weapon bonus)
+      const expectedFinalHp = initialPv - expectedDamage;
+
+      expect(hpAfterEnemyAttack).toBe(expectedFinalHp);
+
+      // Skip back to player turn
+      slice.executeAction({ type: CombatActionType.SKIP });
+
+      // Player kills enemy
+      slice.executeAction({ type: CombatActionType.ATTACK }, { hitDice: [1, 1], damageDice: 6 });
+
+      // Combat should be ended with enemy dead
+      expect(currentState.combat?.enemy.endurance).toBeLessThanOrEqual(0);
+
+      // End combat - this is where the bug occurred
+      await slice.endCombat();
+
+      // Verify updateStats was called with correct HP (not 0, not double damage)
+      expect(currentState.updateStats).toHaveBeenCalledWith(
+        'test-char-id',
+        expect.objectContaining({ pointsDeVieActuels: expectedFinalHp })
+      );
+
+      // Ensure applyDamage was NOT called (the old buggy behavior)
+      expect(currentState.applyDamage).not.toHaveBeenCalled();
     });
 
     it('should not persist changes on cancel', () => {


### PR DESCRIPTION
## Summary

Fix bug #152 where HP was incorrectly set to 0 after winning a combat with damage taken.

## Problem

In Combat V3, damage is applied immediately during combat via `AttackResolver` and `CombatEngine`. However, `endCombat()` was calculating damage differential and calling `applyDamage()`, causing double application:

1. Combat reduces HP from 30 → 15 (15 damage)
2. `endCombat()` calculates `damageTaken = 30 - 15 = 15`
3. `applyDamage(15)` subtracts 15 more → **HP becomes 0** ❌

## Solution

Changed `endCombat()` to use `updateStats()` with direct HP synchronization instead of `applyDamage()`:

```typescript
// Before (buggy)
const damageTaken = combat.player.enduranceMax - combat.player.endurance;
if (damageTaken > 0) {
  await get().applyDamage(characterId, damageTaken);
}

// After (fixed)
await get().updateStats(characterId, {
  pointsDeVieActuels: combat.player.endurance
});
```

## Changes

- **src/presentation/stores/slices/combatSlice.ts**: Fixed `endCombat()` method
- **tests/integration/combat-v2-e2e.test.ts**: Added test case for bug #152

## Testing

- ✅ All 852 tests pass
- ✅ New integration test reproduces and verifies the fix
- ✅ ESLint passes

Closes #152